### PR TITLE
Ignore file if it starts with an underscore

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,12 +13,12 @@ title: Astropy Data Server
 <link href='http://fonts.googleapis.com/css?family=Open+Sans:200,300,400italic,400,700' rel='stylesheet' type='text/css' />
 <link rel="stylesheet" type="text/css" href="css/style.css" />
 
- 
+
 <title>{{ page.title }}</title>
 
 </head>
 
-<body> 
+<body>
 
 
 <div id="wrapper">
@@ -46,8 +46,9 @@ title: Astropy Data Server
    {% for s in site.static_files %}
 
       {% assign firstdir = s.path |remove_first: "/" | split: "/" | first%}
+      {% assign filename = s.path |remove_first: "/" | split: "/" | last%}
 
-      {% if (firstdir == 'css') or (firstdir == 'images') or (firstdir == 'pages-build-version') or (s.path contains 'README.md') %}
+      {% if (firstdir == 'css') or (firstdir == 'images') or (firstdir == 'pages-build-version') or (s.path contains 'README.md') or (filename|first == '_') %}
       {% else %}
         <li><a href="{{ s.path |remove_first: "/" }}">{{ s.path |remove_first: "/" }}</a>
         </li>
@@ -58,12 +59,9 @@ title: Astropy Data Server
   <p>
   A machine-readable JSON list of files is also available: <a href="file_index.json">file_index.json</a>
   </p>
-  
+
 </section>
 </div>
 
 </body>
 </html>
-
-
-


### PR DESCRIPTION
This will make more sense in the context of a future issue or PR by me, but I'd like there to be a way to not index a file on the site. Here I've made it so files that start with an underscore are ignored. 
