### PR TITLE
added sites.json for site astropy site registry

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -1,0 +1,384 @@
+{
+    "tona": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 0, 
+        "name": "Observatorio Astronomico Nacional, Tonantzintla", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 19.032777777777778, 
+        "elevation_unit": "meter", 
+        "longitude": 261.68611111111113, 
+        "aliases": [
+            "Observatorio Astronomico Nacional, Tonantzintla"
+        ]
+    }, 
+    "lick": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 1290, 
+        "name": "Lick Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 37.343333333333334, 
+        "elevation_unit": "meter", 
+        "longitude": 238.36333333333332, 
+        "aliases": [
+            "Lick Observatory"
+        ]
+    }, 
+    "mdm": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 1938, 
+        "name": "Michigan-Dartmouth-MIT Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 31.95, 
+        "elevation_unit": "meter", 
+        "longitude": 248.38333333333333, 
+        "aliases": [
+            "Michigan-Dartmouth-MIT Observatory"
+        ]
+    }, 
+    "lapalma": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2327, 
+        "name": "Roque de los Muchachos, La Palma", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 28.758333333333333, 
+        "elevation_unit": "meter", 
+        "longitude": 342.12, 
+        "aliases": [
+            "Roque de los Muchachos"
+        ]
+    }, 
+    "ctio": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2215, 
+        "name": "Cerro Tololo Interamerican Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": -30.165277777777778, 
+        "elevation_unit": "meter", 
+        "longitude": 289.185, 
+        "aliases": [
+            "Cerro Tololo Interamerican Observatory", 
+            "Cerro Tololo"
+        ]
+    }, 
+    "apo": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2798, 
+        "name": "Apache Point Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 32.78, 
+        "elevation_unit": "meter", 
+        "longitude": 254.17999999999998, 
+        "aliases": [
+            "Apache Point Observatory", 
+            "Apache Point"
+        ]
+    }, 
+    "BAO": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 950, 
+        "name": "Beijing XingLong Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 40.39333333333333, 
+        "elevation_unit": "meter", 
+        "longitude": 117.575, 
+        "aliases": [
+            "Beijing XingLong Observatory"
+        ]
+    }, 
+    "mcdonald": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2075, 
+        "name": "McDonald Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 30.671666694444447, 
+        "elevation_unit": "meter", 
+        "longitude": 255.97833330555557, 
+        "aliases": [
+            "McDonald Observatory"
+        ]
+    }, 
+    "mtbigelow": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2510, 
+        "name": "Catalina Observatory: 61 inch telescope", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 32.416666666666664, 
+        "elevation_unit": "meter", 
+        "longitude": 249.26833333333335, 
+        "aliases": [
+            "Catalina Observatory"
+        ]
+    }, 
+    "mso": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 767, 
+        "name": "Mt. Stromlo Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": -35.32065, 
+        "elevation_unit": "meter", 
+        "longitude": 149.02433333333335, 
+        "aliases": [
+            "Mt. Stromlo Observatory"
+        ]
+    }, 
+    "eso": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2347, 
+        "name": "European Southern Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": -29.256666666666668, 
+        "elevation_unit": "meter", 
+        "longitude": 289.27, 
+        "aliases": [
+            "European Southern Observatory"
+        ]
+    }, 
+    "cfht": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 4215, 
+        "name": "Canada-France-Hawaii Telescope", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 19.826666666666668, 
+        "elevation_unit": "meter", 
+        "longitude": 204.52833333333334, 
+        "aliases": [
+            "Canada-France-Hawaii Telescope"
+        ]
+    }, 
+    "lowell": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2198, 
+        "name": "Lowell Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 35.09666666666667, 
+        "elevation_unit": "meter", 
+        "longitude": 248.46499999999997, 
+        "aliases": [
+            "Lowell Observatory"
+        ]
+    }, 
+    "keck": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 4160, 
+        "name": "W. M. Keck Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 19.828333333333333, 
+        "elevation_unit": "meter", 
+        "longitude": 204.52166666666668, 
+        "aliases": [
+            "W. M. Keck Observatory", 
+            "Keck Observatory"
+        ]
+    }, 
+    "Palomar": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 1706, 
+        "name": "The Hale Telescope", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 33.356, 
+        "elevation_unit": "meter", 
+        "longitude": 243.137, 
+        "aliases": [
+            "Hale Telescope"
+        ]
+    }, 
+    "mmt": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2608, 
+        "name": "Whipple Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 31.688333333333333, 
+        "elevation_unit": "meter", 
+        "longitude": 249.11499999999998, 
+        "aliases": [
+            "Multiple Mirror Telescope"
+        ]
+    }, 
+    "dao": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 229, 
+        "name": "Dominion Astrophysical Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 48.52166666666667, 
+        "elevation_unit": "meter", 
+        "longitude": 236.58333333333334, 
+        "aliases": [
+            "Dominion Astrophysical Observatory"
+        ]
+    }, 
+    "bmo": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 738, 
+        "name": "Black Moshannon Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 40.92166666666667, 
+        "elevation_unit": "meter", 
+        "longitude": 281.995, 
+        "aliases": [
+            "Black Moshannon Observatory"
+        ]
+    }, 
+    "sso": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 1149, 
+        "name": "Siding Spring Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": -31.27336111111111, 
+        "elevation_unit": "meter", 
+        "longitude": 149.06119444444445, 
+        "aliases": [
+            "Siding Spring Observatory"
+        ]
+    }, 
+    "lco": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2282, 
+        "name": "Las Campanas Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": -29.003333333333334, 
+        "elevation_unit": "meter", 
+        "longitude": 289.29833333333335, 
+        "aliases": [
+            "Las Campanas Observatory"
+        ]
+    }, 
+    "kpno": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2120, 
+        "name": "Kitt Peak National Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 31.96333333333333, 
+        "elevation_unit": "meter", 
+        "longitude": 248.4, 
+        "aliases": [
+            "Kitt Peak", 
+            "Kitt Peak National Observatory"
+        ]
+    }, 
+    "aao": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 1164, 
+        "name": "Anglo-Australian Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": -31.27703888888889, 
+        "elevation_unit": "meter", 
+        "longitude": 149.06608611111113, 
+        "aliases": [
+            "Anglo-Australian Observatory"
+        ]
+    }, 
+    "flwo": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2320, 
+        "name": "Whipple Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 31.680944444444446, 
+        "elevation_unit": "meter", 
+        "longitude": 249.1225, 
+        "aliases": [
+            "Whipple", 
+            "Whipple Observatory"
+        ]
+    }, 
+    "ekar": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 1413, 
+        "name": "Mt. Ekar 182 cm. Telescope", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 45.84858888888889, 
+        "elevation_unit": "meter", 
+        "longitude": 11.581133333333334, 
+        "aliases": [
+            "Mt. Ekar 182 cm. Telescope"
+        ]
+    }, 
+    "Subaru": {
+        "source": "Subaru Telescope website (August 2015)", 
+        "elevation": 4139, 
+        "name": "Subaru", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 19.825555555555557, 
+        "elevation_unit": "meter", 
+        "longitude": 204.5238888888889, 
+        "aliases": [
+            "Subaru Telescope"
+        ]
+    }, 
+    "vbo": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 725, 
+        "name": "Vainu Bappu Observatory", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 12.57666, 
+        "elevation_unit": "meter", 
+        "longitude": 78.8266, 
+        "aliases": [
+            "Vainu Bappu Observatory"
+        ]
+    }, 
+    "NOV": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 3610, 
+        "name": "National Observatory of Venezuela", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 8.79, 
+        "elevation_unit": "meter", 
+        "longitude": 289.1333333333333, 
+        "aliases": [
+            "National Observatory of Venezuela"
+        ]
+    }, 
+    "spm": {
+        "source": "IRAF Observatory Database", 
+        "elevation": 2830, 
+        "name": "Observatorio Astronomico Nacional, San Pedro Martir", 
+        "longitude_unit": "degree", 
+        "latitude_unit": "degree", 
+        "latitude": 31.029166666666665, 
+        "elevation_unit": "meter", 
+        "longitude": 244.51305555555555, 
+        "aliases": [
+            "Observatorio Astronomico Nacional, San Pedro Martir"
+        ]
+    },
+    "mro": {
+        "aliases": [
+            "Manastash Ridge Observatory"
+        ],
+        "elevation": 1198,
+        "elevation_unit": "meter",
+        "latitude": 46.9528,
+        "latitude_unit": "degree",
+        "longitude": -120.7278,
+        "longitude_unit": "degree",
+        "name": "mro",
+        "source": "MRO website"
+    }
+}


### PR DESCRIPTION
This is a companion to astropy/astropy#4042 .  If that gets accepted, we can merge this, and then undo the xfails in the tests added in astropy/astropy#4042 . The source for this file is the astropy/astroplan repo, mostly compiled by @bmorris3.

The idea is that in the future anyone can submit changes directly to this repo, and they will then spring up whenever an astropy user uses `EarthLocation.of_site`.
