### PR TITLE
sites.json should contain the full name of site 'mro'

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -405,7 +405,7 @@
         "latitude_unit": "degree",
         "longitude": -120.7278,
         "longitude_unit": "degree",
-        "name": "mro",
+        "name": "Manastash Ridge Observatory",
         "source": "MRO website"
     },
     "haleakala": {


### PR DESCRIPTION
Site `mro` does not have its full name listed in the `name` field, which is inconsistent with all other sites.  This PR fixes that.
