### PR TITLE
Fixes to observatory data

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -35,7 +35,7 @@
         "latitude_unit": "degree",
         "latitude": 19.032777777778,
         "elevation_unit": "meter",
-        "longitude": 261.68611111111,
+        "longitude": -98.313888888889,
         "timezone": "America/Mexico_City",
         "aliases": [
             "Observatorio Astronomico Nacional, Tonantzintla"
@@ -49,7 +49,7 @@
         "latitude_unit": "degree",
         "latitude": 37.343333333333,
         "elevation_unit": "meter",
-        "longitude": 238.36333333333,
+        "longitude": -121.63666666667,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "Lick Observatory"
@@ -63,7 +63,7 @@
         "latitude_unit": "degree",
         "latitude": 31.95,
         "elevation_unit": "meter",
-        "longitude": 248.38333333333,
+        "longitude": -111.61666666667,
         "timezone": "America/Phoenix",
         "aliases": [
             "Michigan-Dartmouth-MIT Observatory"
@@ -77,7 +77,7 @@
         "latitude_unit": "degree",
         "latitude": 28.758333333333,
         "elevation_unit": "meter",
-        "longitude": 342.12,
+        "longitude": -17.88,
         "timezone": "Atlantic/Canary",
         "aliases": [
             "Roque de los Muchachos"
@@ -91,7 +91,7 @@
         "latitude_unit": "degree",
         "latitude": -30.165277777778,
         "elevation_unit": "meter",
-        "longitude": 289.185,
+        "longitude": -70.815,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Tololo Interamerican Observatory",
@@ -106,7 +106,7 @@
         "latitude_unit": "degree",
         "latitude": 32.78,
         "elevation_unit": "meter",
-        "longitude": 254.18,
+        "longitude": -105.82,
         "timezone": "America/Denver",
         "aliases": [
             "Apache Point Observatory",
@@ -135,7 +135,7 @@
         "latitude_unit": "degree",
         "latitude": 30.671666694444,
         "elevation_unit": "meter",
-        "longitude": 255.97833330556,
+        "longitude": -104.02166669444,
         "timezone": "America/Chicago",
         "aliases": [
             "McDonald Observatory"
@@ -149,7 +149,7 @@
         "latitude_unit": "degree",
         "latitude": 32.416666666667,
         "elevation_unit": "meter",
-        "longitude": 249.26833333333,
+        "longitude": -110.73166666667,
         "timezone": "America/Phoenix",
         "aliases": [
             "Catalina Observatory"
@@ -177,7 +177,7 @@
         "latitude_unit": "degree",
         "latitude": -29.256666666667,
         "elevation_unit": "meter",
-        "longitude": 289.27,
+        "longitude": -70.73,
         "timezone": "America/Santiago",
         "aliases": [
             "La Silla Observatory"
@@ -191,7 +191,7 @@
         "latitude_unit": "degree",
         "latitude": -24.6252,
         "elevation_unit": "meter",
-        "longitude": 289.597,
+        "longitude": -70.403,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Paranal",
@@ -206,7 +206,7 @@
         "latitude_unit": "degree",
         "latitude": 19.826666666667,
         "elevation_unit": "meter",
-        "longitude": 204.52833333333,
+        "longitude": -155.47166666667,
         "timezone": "Pacific/Honolulu",
         "aliases": [
             "Canada-France-Hawaii Telescope"
@@ -220,7 +220,7 @@
         "latitude_unit": "degree",
         "latitude": 35.096666666667,
         "elevation_unit": "meter",
-        "longitude": 248.465,
+        "longitude": -111.535,
         "timezone": "America/Phoenix",
         "aliases": [
             "Lowell Observatory"
@@ -234,7 +234,7 @@
         "latitude_unit": "degree",
         "latitude": 19.828333333333,
         "elevation_unit": "meter",
-        "longitude": 204.52166666667,
+        "longitude": -155.47833333333,
         "timezone": "Pacific/Honolulu",
         "aliases": [
             "W. M. Keck Observatory",
@@ -249,7 +249,7 @@
         "latitude_unit": "degree",
         "latitude": 33.356,
         "elevation_unit": "meter",
-        "longitude": 243.137,
+        "longitude": -116.863,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "Hale Telescope"
@@ -263,7 +263,7 @@
         "latitude_unit": "degree",
         "latitude": 31.688333333333,
         "elevation_unit": "meter",
-        "longitude": 249.115,
+        "longitude": -110.885,
         "timezone": "America/Phoenix",
         "aliases": [
             "Multiple Mirror Telescope"
@@ -277,7 +277,7 @@
         "latitude_unit": "degree",
         "latitude": 48.521666666667,
         "elevation_unit": "meter",
-        "longitude": 236.58333333333,
+        "longitude": -123.41666666667,
         "timezone": "America/Vancouver",
         "aliases": [
             "Dominion Astrophysical Observatory"
@@ -291,7 +291,7 @@
         "latitude_unit": "degree",
         "latitude": 40.921666666667,
         "elevation_unit": "meter",
-        "longitude": 281.995,
+        "longitude": -78.005,
         "timezone": "America/New_York",
         "aliases": [
             "Black Moshannon Observatory"
@@ -319,7 +319,7 @@
         "latitude_unit": "degree",
         "latitude": -29.003333333333,
         "elevation_unit": "meter",
-        "longitude": 289.29833333333,
+        "longitude": -70.701666666667,
         "timezone": "America/Santiago",
         "aliases": [
             "Las Campanas Observatory"
@@ -333,7 +333,7 @@
         "latitude_unit": "degree",
         "latitude": 31.963333333333,
         "elevation_unit": "meter",
-        "longitude": 248.4,
+        "longitude": -111.6,
         "timezone": "America/Phoenix",
         "aliases": [
             "Kitt Peak",
@@ -362,7 +362,7 @@
         "latitude_unit": "degree",
         "latitude": 31.680944444444,
         "elevation_unit": "meter",
-        "longitude": 249.1225,
+        "longitude": -110.8775,
         "timezone": "America/Phoenix",
         "aliases": [
             "Whipple",
@@ -391,7 +391,7 @@
         "latitude_unit": "degree",
         "latitude": 19.825555555556,
         "elevation_unit": "meter",
-        "longitude": 204.52388888889,
+        "longitude": -155.47611111111,
         "timezone": "Pacific/Honolulu",
         "aliases": [
             "Subaru Telescope"
@@ -419,7 +419,7 @@
         "latitude_unit": "degree",
         "latitude": 8.79,
         "elevation_unit": "meter",
-        "longitude": 289.13333333333,
+        "longitude": -70.866666666667,
         "timezone": "America/Caracas",
         "aliases": [
             "National Observatory of Venezuela"
@@ -433,7 +433,7 @@
         "latitude_unit": "degree",
         "latitude": 31.029166666667,
         "elevation_unit": "meter",
-        "longitude": 244.51305555556,
+        "longitude": -115.48694444444,
         "timezone": "America/Tijuana",
         "aliases": [
             "Observatorio Astronomico Nacional, San Pedro Martir"
@@ -461,7 +461,7 @@
         "latitude_unit": "degree",
         "latitude": 20.71552,
         "elevation_unit": "meter",
-        "longitude": 203.831,
+        "longitude": -156.169,
         "timezone": "Pacific/Honolulu",
         "aliases": [
             "Haleakala Observatories"
@@ -475,7 +475,7 @@
         "latitude_unit": "degree",
         "latitude": -30.240741666667,
         "elevation_unit": "meter",
-        "longitude": 289.26331666667,
+        "longitude": -70.736683333333,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Pachon",
@@ -519,7 +519,7 @@
         "latitude_unit": "degree",
         "latitude": 32.7016,
         "elevation_unit": "meter",
-        "longitude": 250.1281,
+        "longitude": -109.8719,
         "timezone": "America/Phoenix",
         "aliases": [
             "Large Binocular Telescope",
@@ -623,7 +623,7 @@
         "latitude_unit": "degree",
         "latitude": 34.744305,
         "elevation_unit": "meter",
-        "longitude": 248.577485,
+        "longitude": -111.422515,
         "aliases": [
             "DCT",
             "Discovery Channel Telescope",

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -29,7 +29,7 @@
     },
     "tona": {
         "source": "IRAF Observatory Database",
-        "elevation": 0,
+        "elevation": 2174,
         "name": "Observatorio Astronomico Nacional, Tonantzintla",
         "longitude_unit": "degree",
         "latitude_unit": "degree",

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -8,7 +8,7 @@
         "latitude": 51.477811,
         "elevation_unit": "meter",
         "longitude": -0.001475,
-        "timezone": "Greenwich",
+        "timezone": "Europe/London",
         "aliases": [
             "example_site"
         ]
@@ -19,9 +19,9 @@
         "name": "Mount Wilson Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 34.222579805555554,
+        "latitude": 34.222579805556,
         "elevation_unit": "meter",
-        "longitude": -118.06168400000001,
+        "longitude": -118.061684,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "CHARA"
@@ -33,10 +33,10 @@
         "name": "Observatorio Astronomico Nacional, Tonantzintla",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.032777777777778,
+        "latitude": 19.032777777778,
         "elevation_unit": "meter",
-        "longitude": 261.68611111111113,
-        "timezone": "US/Central",
+        "longitude": 261.68611111111,
+        "timezone": "America/Mexico_City",
         "aliases": [
             "Observatorio Astronomico Nacional, Tonantzintla"
         ]
@@ -47,10 +47,10 @@
         "name": "Lick Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 37.343333333333334,
+        "latitude": 37.343333333333,
         "elevation_unit": "meter",
-        "longitude": 238.36333333333332,
-        "timezone": "US/Pacific",
+        "longitude": 238.36333333333,
+        "timezone": "America/Los_Angeles",
         "aliases": [
             "Lick Observatory"
         ]
@@ -63,8 +63,8 @@
         "latitude_unit": "degree",
         "latitude": 31.95,
         "elevation_unit": "meter",
-        "longitude": 248.38333333333333,
-        "timezone": "US/Mountain",
+        "longitude": 248.38333333333,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Michigan-Dartmouth-MIT Observatory"
         ]
@@ -75,7 +75,7 @@
         "name": "Roque de los Muchachos, La Palma",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 28.758333333333333,
+        "latitude": 28.758333333333,
         "elevation_unit": "meter",
         "longitude": 342.12,
         "timezone": "Atlantic/Canary",
@@ -89,10 +89,10 @@
         "name": "Cerro Tololo Interamerican Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.165277777777778,
+        "latitude": -30.165277777778,
         "elevation_unit": "meter",
         "longitude": 289.185,
-        "timezone": "Chile/Continental",
+        "timezone": "America/Santiago",
         "aliases": [
             "Cerro Tololo Interamerican Observatory",
             "Cerro Tololo"
@@ -106,8 +106,8 @@
         "latitude_unit": "degree",
         "latitude": 32.78,
         "elevation_unit": "meter",
-        "longitude": 254.17999999999998,
-        "timezone": "US/Mountain",
+        "longitude": 254.18,
+        "timezone": "America/Denver",
         "aliases": [
             "Apache Point Observatory",
             "Apache Point"
@@ -119,7 +119,7 @@
         "name": "Beijing XingLong Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.39333333333333,
+        "latitude": 40.393333333333,
         "elevation_unit": "meter",
         "longitude": 117.575,
         "timezone": "Asia/Shanghai",
@@ -133,10 +133,10 @@
         "name": "McDonald Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 30.671666694444447,
+        "latitude": 30.671666694444,
         "elevation_unit": "meter",
-        "longitude": 255.97833330555557,
-        "timezone": "US/Central",
+        "longitude": 255.97833330556,
+        "timezone": "America/Chicago",
         "aliases": [
             "McDonald Observatory"
         ]
@@ -147,10 +147,10 @@
         "name": "Catalina Observatory: 61 inch telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 32.416666666666664,
+        "latitude": 32.416666666667,
         "elevation_unit": "meter",
-        "longitude": 249.26833333333335,
-        "timezone": "US/Mountain",
+        "longitude": 249.26833333333,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Catalina Observatory"
         ]
@@ -163,7 +163,7 @@
         "latitude_unit": "degree",
         "latitude": -35.32065,
         "elevation_unit": "meter",
-        "longitude": 149.02433333333335,
+        "longitude": 149.02433333333,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Mt. Stromlo Observatory"
@@ -175,10 +175,10 @@
         "name": "La Silla Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.256666666666668,
+        "latitude": -29.256666666667,
         "elevation_unit": "meter",
         "longitude": 289.27,
-        "timezone": "Chile/Continental",
+        "timezone": "America/Santiago",
         "aliases": [
             "La Silla Observatory"
         ]
@@ -192,7 +192,7 @@
         "latitude": -24.6252,
         "elevation_unit": "meter",
         "longitude": 289.597,
-        "timezone": "Chile/Continental",
+        "timezone": "America/Santiago",
         "aliases": [
             "Cerro Paranal",
             "Paranal Observatory"
@@ -204,10 +204,10 @@
         "name": "Canada-France-Hawaii Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.826666666666668,
+        "latitude": 19.826666666667,
         "elevation_unit": "meter",
-        "longitude": 204.52833333333334,
-        "timezone": "US/Aleutian",
+        "longitude": 204.52833333333,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "Canada-France-Hawaii Telescope"
         ]
@@ -218,10 +218,10 @@
         "name": "Lowell Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 35.09666666666667,
+        "latitude": 35.096666666667,
         "elevation_unit": "meter",
-        "longitude": 248.46499999999997,
-        "timezone": "US/Mountain",
+        "longitude": 248.465,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Lowell Observatory"
         ]
@@ -232,10 +232,10 @@
         "name": "W. M. Keck Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.828333333333333,
+        "latitude": 19.828333333333,
         "elevation_unit": "meter",
-        "longitude": 204.52166666666668,
-        "timezone": "US/Aleutian",
+        "longitude": 204.52166666667,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "W. M. Keck Observatory",
             "Keck Observatory"
@@ -250,7 +250,7 @@
         "latitude": 33.356,
         "elevation_unit": "meter",
         "longitude": 243.137,
-        "timezone": "US/Pacific",
+        "timezone": "America/Los_Angeles",
         "aliases": [
             "Hale Telescope"
         ]
@@ -261,10 +261,10 @@
         "name": "Multiple Mirror Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.688333333333333,
+        "latitude": 31.688333333333,
         "elevation_unit": "meter",
-        "longitude": 249.11499999999998,
-        "timezone": "US/Mountain",
+        "longitude": 249.115,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Multiple Mirror Telescope"
         ]
@@ -275,10 +275,10 @@
         "name": "Dominion Astrophysical Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 48.52166666666667,
+        "latitude": 48.521666666667,
         "elevation_unit": "meter",
-        "longitude": 236.58333333333334,
-        "timezone": "US/Pacific",
+        "longitude": 236.58333333333,
+        "timezone": "America/Vancouver",
         "aliases": [
             "Dominion Astrophysical Observatory"
         ]
@@ -289,10 +289,10 @@
         "name": "Black Moshannon Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.92166666666667,
+        "latitude": 40.921666666667,
         "elevation_unit": "meter",
         "longitude": 281.995,
-        "timezone": "US/Eastern",
+        "timezone": "America/New_York",
         "aliases": [
             "Black Moshannon Observatory"
         ]
@@ -303,9 +303,9 @@
         "name": "Siding Spring Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -31.27336111111111,
+        "latitude": -31.273361111111,
         "elevation_unit": "meter",
-        "longitude": 149.06119444444445,
+        "longitude": 149.06119444444,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Siding Spring Observatory"
@@ -317,10 +317,10 @@
         "name": "Las Campanas Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.003333333333334,
+        "latitude": -29.003333333333,
         "elevation_unit": "meter",
-        "longitude": 289.29833333333335,
-        "timezone": "Chile/Continental",
+        "longitude": 289.29833333333,
+        "timezone": "America/Santiago",
         "aliases": [
             "Las Campanas Observatory"
         ]
@@ -331,10 +331,10 @@
         "name": "Kitt Peak National Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.96333333333333,
+        "latitude": 31.963333333333,
         "elevation_unit": "meter",
         "longitude": 248.4,
-        "timezone": "US/Mountain",
+        "timezone": "America/Phoenix",
         "aliases": [
             "Kitt Peak",
             "Kitt Peak National Observatory"
@@ -346,9 +346,9 @@
         "name": "Anglo-Australian Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -31.27703888888889,
+        "latitude": -31.277038888889,
         "elevation_unit": "meter",
-        "longitude": 149.06608611111113,
+        "longitude": 149.06608611111,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Anglo-Australian Observatory"
@@ -360,10 +360,10 @@
         "name": "Whipple Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.680944444444446,
+        "latitude": 31.680944444444,
         "elevation_unit": "meter",
         "longitude": 249.1225,
-        "timezone": "US/Mountain",
+        "timezone": "America/Phoenix",
         "aliases": [
             "Whipple",
             "Whipple Observatory"
@@ -375,10 +375,10 @@
         "name": "Mt. Ekar 182 cm. Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 45.84858888888889,
+        "latitude": 45.848588888889,
         "elevation_unit": "meter",
-        "longitude": 11.581133333333334,
-        "timezone": "CET",
+        "longitude": 11.581133333333,
+        "timezone": "Europe/Rome",
         "aliases": [
             "Mt. Ekar 182 cm. Telescope"
         ]
@@ -389,10 +389,10 @@
         "name": "Subaru Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.825555555555557,
+        "latitude": 19.825555555556,
         "elevation_unit": "meter",
-        "longitude": 204.5238888888889,
-        "timezone": "US/Aleutian",
+        "longitude": 204.52388888889,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "Subaru Telescope"
         ]
@@ -419,7 +419,7 @@
         "latitude_unit": "degree",
         "latitude": 8.79,
         "elevation_unit": "meter",
-        "longitude": 289.1333333333333,
+        "longitude": 289.13333333333,
         "timezone": "America/Caracas",
         "aliases": [
             "National Observatory of Venezuela"
@@ -431,10 +431,10 @@
         "name": "Observatorio Astronomico Nacional, San Pedro Martir",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.029166666666665,
+        "latitude": 31.029166666667,
         "elevation_unit": "meter",
-        "longitude": 244.51305555555555,
-        "timezone": "US/Pacific",
+        "longitude": 244.51305555556,
+        "timezone": "America/Tijuana",
         "aliases": [
             "Observatorio Astronomico Nacional, San Pedro Martir"
         ]
@@ -448,7 +448,7 @@
         "latitude": 46.9528,
         "latitude_unit": "degree",
         "longitude": -120.7278,
-        "timezone": "US/Pacific",
+        "timezone": "America/Los_Angeles",
         "longitude_unit": "degree",
         "name": "Manastash Ridge Observatory",
         "source": "MRO website"
@@ -462,7 +462,7 @@
         "latitude": 20.71552,
         "elevation_unit": "meter",
         "longitude": 203.831,
-        "timezone": "US/Aleutian",
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "Haleakala Observatories"
         ]
@@ -473,14 +473,14 @@
         "name": "Gemini South",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.24074166666667,
+        "latitude": -30.240741666667,
         "elevation_unit": "meter",
-        "longitude": 289.2633166666667,
-        "timezone": "Chile/Continental",
+        "longitude": 289.26331666667,
+        "timezone": "America/Santiago",
         "aliases": [
-             "Cerro Pachon",
-             "Gemini South",
-             "gems"
+            "Cerro Pachon",
+            "Gemini South",
+            "gems"
         ]
     },
     "gemini_north": {
@@ -489,12 +489,12 @@
         "name": "Gemini North",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.823801447222223,
+        "latitude": 19.823801447222,
         "elevation_unit": "meter",
-        "longitude": 155.4690467527778,
-        "timezone": "US/Aleutian",
+        "longitude": 155.46904675278,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
-             "gemn"
+            "gemn"
         ]
     },
     "irtf": {
@@ -503,12 +503,12 @@
         "name": "NASA Infrared Telescope Facility",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.826218316666665,
+        "latitude": 19.826218316667,
         "elevation_unit": "meter",
-        "longitude": 155.4719987888889,
-        "timezone": "US/Aleutian",
+        "longitude": 155.47199878889,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
-             ""
+            ""
         ]
     },
     "lbt": {
@@ -520,11 +520,11 @@
         "latitude": 32.7016,
         "elevation_unit": "meter",
         "longitude": 250.1281,
-        "timezone": "US/Mountain",
+        "timezone": "America/Phoenix",
         "aliases": [
-             "Large Binocular Telescope",
-             "Mount Graham International Observatory",
-             "Mt Graham"
+            "Large Binocular Telescope",
+            "Mount Graham International Observatory",
+            "Mt Graham"
         ]
     },
     "salt": {
@@ -538,53 +538,53 @@
         "longitude": 20.810808,
         "timezone": "Africa/Johannesburg",
         "aliases": [
-             "SALT",
-             "Southern African Large Telescope",
-             "SAAO",
-             "Sutherland"
+            "SALT",
+            "Southern African Large Telescope",
+            "SAAO",
+            "Sutherland"
         ]
     },
     "srt": {
         "source": "SRT website & google maps",
-        "elevation": 650.0,
+        "elevation": 650,
         "name": "Sardinia Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 39.493040,
+        "latitude": 39.49304,
         "elevation_unit": "meter",
         "longitude": 9.24516,
-        "timezone": "CET",
+        "timezone": "Europe/Rome",
         "aliases": [
-             "SRT"
+            "SRT"
         ]
     },
     "medicina": {
         "source": "Medicina Radio Telescope website & google maps",
-        "elevation": 25.0,
+        "elevation": 25,
         "name": "Medicina Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 44.5205,
         "elevation_unit": "meter",
         "longitude": 11.6469,
-        "timezone": "CET",
+        "timezone": "Europe/Rome",
         "aliases": [
-             "Medicina Dish",
-             "Medicina"
+            "Medicina Dish",
+            "Medicina"
         ]
     },
     "noto": {
         "source": "Noto Radio Telescope website & google maps",
-        "elevation": 30.0,
+        "elevation": 30,
         "name": "Noto Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 36.87585,
         "elevation_unit": "meter",
         "longitude": 14.9889,
-        "timezone": "CET",
+        "timezone": "Europe/Rome",
         "aliases": [
-             "Noto"
+            "Noto"
         ]
     },
     "ohp": {
@@ -593,12 +593,12 @@
         "name": "Observatoire de Haute Provence",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 43.93083333333333,
+        "latitude": 43.930833333333,
         "elevation_unit": "meter",
-        "longitude": 5.713333333333333,
-        "timezone": "CET",
+        "longitude": 5.7133333333333,
+        "timezone": "Europe/Paris",
         "aliases": [
-             ""
+            ""
         ]
     },
     "sirene": {
@@ -607,17 +607,17 @@
         "name": "Observatoire SIRENE",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 44.0,
+        "latitude": 44,
         "elevation_unit": "meter",
-        "longitude": 5.486944444444444,
-        "timezone": "CET",
+        "longitude": 5.4869444444444,
+        "timezone": "Europe/Paris",
         "aliases": [
-             ""
+            ""
         ]
     },
     "dct": {
         "source": "Site GPS on 20130708 UT as recorded in observatory wiki",
-        "elevation": 2337.0,
+        "elevation": 2337,
         "name": "Discovery Channel Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
@@ -625,10 +625,11 @@
         "elevation_unit": "meter",
         "longitude": 248.577485,
         "aliases": [
-             "DCT",
-             "Discovery Channel Telescope",
-             "Happy Jack"
-        ]
+            "DCT",
+            "Discovery Channel Telescope",
+            "Happy Jack"
+        ],
+        "timezone": "America/Phoenix"
     },
     "vla": {
         "aliases": [
@@ -637,12 +638,13 @@
         ],
         "elevation": 2124,
         "elevation_unit": "meter",
-        "latitude": 34.07874916666667,
+        "latitude": 34.078749166667,
         "latitude_unit": "degree",
-        "longitude": -107.61828305555555,
+        "longitude": -107.61828305556,
         "longitude_unit": "degree",
         "name": "vla",
-        "source": "wikipedia article"
+        "source": "wikipedia article",
+        "timezone": "America/Denver"
     },
     "alma": {
         "aliases": [
@@ -656,6 +658,7 @@
         "longitude": -67.755,
         "longitude_unit": "degree",
         "name": "alma",
-        "source": "https://almascience.eso.org/about-alma/alma-site"
+        "source": "https://almascience.eso.org/about-alma/alma-site",
+        "timezone": "America/Santiago"
     }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -8,9 +8,9 @@
         "latitude": 51.477811,
         "elevation_unit": "meter",
         "longitude": -0.001475,
-        "timezone": "Europe/London",
+        "timezone": "Greenwich",
         "aliases": [
-            "ROG"
+            "example_site"
         ]
     },
     "mwo": {
@@ -19,9 +19,9 @@
         "name": "Mount Wilson Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 34.2259,
+        "latitude": 34.222579805555554,
         "elevation_unit": "meter",
-        "longitude": -118.057,
+        "longitude": -118.06168400000001,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "CHARA"
@@ -29,14 +29,14 @@
     },
     "tona": {
         "source": "IRAF Observatory Database",
-        "elevation": 2174,
+        "elevation": 0,
         "name": "Observatorio Astronomico Nacional, Tonantzintla",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.032777777778,
+        "latitude": 19.032777777777778,
         "elevation_unit": "meter",
-        "longitude": -98.313888888889,
-        "timezone": "America/Mexico_City",
+        "longitude": 261.68611111111113,
+        "timezone": "US/Central",
         "aliases": [
             "Observatorio Astronomico Nacional, Tonantzintla"
         ]
@@ -47,10 +47,10 @@
         "name": "Lick Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 37.343333333333,
+        "latitude": 37.343333333333334,
         "elevation_unit": "meter",
-        "longitude": -121.63666666667,
-        "timezone": "America/Los_Angeles",
+        "longitude": 238.36333333333332,
+        "timezone": "US/Pacific",
         "aliases": [
             "Lick Observatory"
         ]
@@ -63,8 +63,8 @@
         "latitude_unit": "degree",
         "latitude": 31.95,
         "elevation_unit": "meter",
-        "longitude": -111.61666666667,
-        "timezone": "America/Phoenix",
+        "longitude": 248.38333333333333,
+        "timezone": "US/Mountain",
         "aliases": [
             "Michigan-Dartmouth-MIT Observatory"
         ]
@@ -75,18 +75,12 @@
         "name": "Roque de los Muchachos, La Palma",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 28.758333333333,
+        "latitude": 28.758333333333333,
         "elevation_unit": "meter",
-        "longitude": -17.88,
+        "longitude": 342.12,
         "timezone": "Atlantic/Canary",
         "aliases": [
-            "Roque de los Muchachos",
-            "Isaac Newton group",
-            "ING",
-            "William Herschel Telescope",
-            "WHT",
-            "Grantecan",
-            "GTC"
+            "Roque de los Muchachos"
         ]
     },
     "ctio": {
@@ -95,10 +89,10 @@
         "name": "Cerro Tololo Interamerican Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.169,
+        "latitude": -30.165277777777778,
         "elevation_unit": "meter",
-        "longitude": -70.8062,
-        "timezone": "America/Santiago",
+        "longitude": 289.185,
+        "timezone": "Chile/Continental",
         "aliases": [
             "Cerro Tololo Interamerican Observatory",
             "Cerro Tololo"
@@ -112,8 +106,8 @@
         "latitude_unit": "degree",
         "latitude": 32.78,
         "elevation_unit": "meter",
-        "longitude": -105.82,
-        "timezone": "America/Denver",
+        "longitude": 254.17999999999998,
+        "timezone": "US/Mountain",
         "aliases": [
             "Apache Point Observatory",
             "Apache Point"
@@ -125,13 +119,12 @@
         "name": "Beijing XingLong Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.3957,
+        "latitude": 40.39333333333333,
         "elevation_unit": "meter",
-        "longitude": 117.5759,
+        "longitude": 117.575,
         "timezone": "Asia/Shanghai",
         "aliases": [
-            "Beijing XingLong Observatory",
-            "LAMOST"
+            "Beijing XingLong Observatory"
         ]
     },
     "mcdonald": {
@@ -140,10 +133,10 @@
         "name": "McDonald Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 30.671666694444,
+        "latitude": 30.671666694444447,
         "elevation_unit": "meter",
-        "longitude": -104.02166669444,
-        "timezone": "America/Chicago",
+        "longitude": 255.97833330555557,
+        "timezone": "US/Central",
         "aliases": [
             "McDonald Observatory"
         ]
@@ -154,13 +147,12 @@
         "name": "Catalina Observatory: 61 inch telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 32.416666666667,
+        "latitude": 32.416666666666664,
         "elevation_unit": "meter",
-        "longitude": -110.73166666667,
-        "timezone": "America/Phoenix",
+        "longitude": 249.26833333333335,
+        "timezone": "US/Mountain",
         "aliases": [
-            "Catalina Observatory",
-            "Mount Bigelow"
+            "Catalina Observatory"
         ]
     },
     "mso": {
@@ -171,7 +163,7 @@
         "latitude_unit": "degree",
         "latitude": -35.32065,
         "elevation_unit": "meter",
-        "longitude": 149.02433333333,
+        "longitude": 149.02433333333335,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Mt. Stromlo Observatory"
@@ -183,14 +175,12 @@
         "name": "La Silla Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.259,
+        "latitude": -29.256666666666668,
         "elevation_unit": "meter",
-        "longitude": -70.7338,
-        "timezone": "America/Santiago",
+        "longitude": 289.27,
+        "timezone": "Chile/Continental",
         "aliases": [
-            "La Silla Observatory",
-            "NTT",
-            "ESO 3.6m"
+            "La Silla Observatory"
         ]
     },
     "paranal": {
@@ -199,18 +189,13 @@
         "name": "Paranal Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -24.6275,
+        "latitude": -24.6252,
         "elevation_unit": "meter",
-        "longitude": -70.4045,
-        "timezone": "America/Santiago",
+        "longitude": 289.597,
+        "timezone": "Chile/Continental",
         "aliases": [
             "Cerro Paranal",
-            "Paranal Observatory",
-            "Very Large Telescope",
-            "VLT",
-            "VST",
-            "VISTA",
-            "NGST"
+            "Paranal Observatory"
         ]
     },
     "cfht": {
@@ -219,10 +204,10 @@
         "name": "Canada-France-Hawaii Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.826666666667,
+        "latitude": 19.826666666666668,
         "elevation_unit": "meter",
-        "longitude": -155.47166666667,
-        "timezone": "Pacific/Honolulu",
+        "longitude": 204.52833333333334,
+        "timezone": "US/Aleutian",
         "aliases": [
             "Canada-France-Hawaii Telescope"
         ]
@@ -233,10 +218,10 @@
         "name": "Lowell Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 35.096666666667,
+        "latitude": 35.09666666666667,
         "elevation_unit": "meter",
-        "longitude": -111.535,
-        "timezone": "America/Phoenix",
+        "longitude": 248.46499999999997,
+        "timezone": "US/Mountain",
         "aliases": [
             "Lowell Observatory"
         ]
@@ -247,10 +232,10 @@
         "name": "W. M. Keck Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.828333333333,
+        "latitude": 19.828333333333333,
         "elevation_unit": "meter",
-        "longitude": -155.47833333333,
-        "timezone": "Pacific/Honolulu",
+        "longitude": 204.52166666666668,
+        "timezone": "US/Aleutian",
         "aliases": [
             "W. M. Keck Observatory",
             "Keck Observatory"
@@ -259,13 +244,13 @@
     "Palomar": {
         "source": "IRAF Observatory Database",
         "elevation": 1706,
-        "name": "Hale Telescope",
+        "name": "The Hale Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 33.356,
         "elevation_unit": "meter",
-        "longitude": -116.863,
-        "timezone": "America/Los_Angeles",
+        "longitude": 243.137,
+        "timezone": "US/Pacific",
         "aliases": [
             "Hale Telescope"
         ]
@@ -276,10 +261,10 @@
         "name": "Multiple Mirror Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.688333333333,
+        "latitude": 31.688333333333333,
         "elevation_unit": "meter",
-        "longitude": -110.885,
-        "timezone": "America/Phoenix",
+        "longitude": 249.11499999999998,
+        "timezone": "US/Mountain",
         "aliases": [
             "Multiple Mirror Telescope"
         ]
@@ -290,10 +275,10 @@
         "name": "Dominion Astrophysical Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 48.521666666667,
+        "latitude": 48.52166666666667,
         "elevation_unit": "meter",
-        "longitude": -123.41666666667,
-        "timezone": "America/Vancouver",
+        "longitude": 236.58333333333334,
+        "timezone": "US/Pacific",
         "aliases": [
             "Dominion Astrophysical Observatory"
         ]
@@ -304,10 +289,10 @@
         "name": "Black Moshannon Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.921666666667,
+        "latitude": 40.92166666666667,
         "elevation_unit": "meter",
-        "longitude": -78.005,
-        "timezone": "America/New_York",
+        "longitude": 281.995,
+        "timezone": "US/Eastern",
         "aliases": [
             "Black Moshannon Observatory"
         ]
@@ -318,9 +303,9 @@
         "name": "Siding Spring Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -31.273361111111,
+        "latitude": -31.27336111111111,
         "elevation_unit": "meter",
-        "longitude": 149.06119444444,
+        "longitude": 149.06119444444445,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Siding Spring Observatory"
@@ -332,10 +317,10 @@
         "name": "Las Campanas Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.0142,
+        "latitude": -29.003333333333334,
         "elevation_unit": "meter",
-        "longitude": -70.6925,
-        "timezone": "America/Santiago",
+        "longitude": 289.29833333333335,
+        "timezone": "Chile/Continental",
         "aliases": [
             "Las Campanas Observatory"
         ]
@@ -346,10 +331,10 @@
         "name": "Kitt Peak National Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.963333333333,
+        "latitude": 31.96333333333333,
         "elevation_unit": "meter",
-        "longitude": -111.6,
-        "timezone": "America/Phoenix",
+        "longitude": 248.4,
+        "timezone": "US/Mountain",
         "aliases": [
             "Kitt Peak",
             "Kitt Peak National Observatory"
@@ -358,12 +343,12 @@
     "aao": {
         "source": "IRAF Observatory Database",
         "elevation": 1164,
-        "name": "Australian Astronomical Observatory",
+        "name": "Anglo-Australian Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -31.277038888889,
+        "latitude": -31.27703888888889,
         "elevation_unit": "meter",
-        "longitude": 149.06608611111,
+        "longitude": 149.06608611111113,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Anglo-Australian Observatory"
@@ -375,10 +360,10 @@
         "name": "Whipple Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.680944444444,
+        "latitude": 31.680944444444446,
         "elevation_unit": "meter",
-        "longitude": -110.8775,
-        "timezone": "America/Phoenix",
+        "longitude": 249.1225,
+        "timezone": "US/Mountain",
         "aliases": [
             "Whipple",
             "Whipple Observatory"
@@ -390,10 +375,10 @@
         "name": "Mt. Ekar 182 cm. Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 45.848588888889,
+        "latitude": 45.84858888888889,
         "elevation_unit": "meter",
-        "longitude": 11.581133333333,
-        "timezone": "Europe/Rome",
+        "longitude": 11.581133333333334,
+        "timezone": "CET",
         "aliases": [
             "Mt. Ekar 182 cm. Telescope"
         ]
@@ -404,10 +389,10 @@
         "name": "Subaru Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.825555555556,
+        "latitude": 19.825555555555557,
         "elevation_unit": "meter",
-        "longitude": -155.47611111111,
-        "timezone": "Pacific/Honolulu",
+        "longitude": 204.5238888888889,
+        "timezone": "US/Aleutian",
         "aliases": [
             "Subaru Telescope"
         ]
@@ -434,7 +419,7 @@
         "latitude_unit": "degree",
         "latitude": 8.79,
         "elevation_unit": "meter",
-        "longitude": -70.866666666667,
+        "longitude": 289.1333333333333,
         "timezone": "America/Caracas",
         "aliases": [
             "National Observatory of Venezuela"
@@ -446,10 +431,10 @@
         "name": "Observatorio Astronomico Nacional, San Pedro Martir",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.029166666667,
+        "latitude": 31.029166666666665,
         "elevation_unit": "meter",
-        "longitude": -115.48694444444,
-        "timezone": "America/Tijuana",
+        "longitude": 244.51305555555555,
+        "timezone": "US/Pacific",
         "aliases": [
             "Observatorio Astronomico Nacional, San Pedro Martir"
         ]
@@ -463,7 +448,7 @@
         "latitude": 46.9528,
         "latitude_unit": "degree",
         "longitude": -120.7278,
-        "timezone": "America/Los_Angeles",
+        "timezone": "US/Pacific",
         "longitude_unit": "degree",
         "name": "Manastash Ridge Observatory",
         "source": "MRO website"
@@ -476,8 +461,8 @@
         "latitude_unit": "degree",
         "latitude": 20.71552,
         "elevation_unit": "meter",
-        "longitude": -156.169,
-        "timezone": "Pacific/Honolulu",
+        "longitude": 203.831,
+        "timezone": "US/Aleutian",
         "aliases": [
             "Haleakala Observatories"
         ]
@@ -488,14 +473,14 @@
         "name": "Gemini South",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.240741666667,
+        "latitude": -30.24074166666667,
         "elevation_unit": "meter",
-        "longitude": -70.736683333333,
-        "timezone": "America/Santiago",
+        "longitude": 289.2633166666667,
+        "timezone": "Chile/Continental",
         "aliases": [
-            "Cerro Pachon",
-            "Gemini South",
-            "gems"
+             "Cerro Pachon",
+             "Gemini South",
+             "gems"
         ]
     },
     "gemini_north": {
@@ -504,12 +489,12 @@
         "name": "Gemini North",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.823801447222,
+        "latitude": 19.823801447222223,
         "elevation_unit": "meter",
-        "longitude": -155.46904675278,
-        "timezone": "Pacific/Honolulu",
+        "longitude": -155.4690467527778,
+        "timezone": "US/Aleutian",
         "aliases": [
-            "gemn"
+             "gemn"
         ]
     },
     "irtf": {
@@ -518,11 +503,13 @@
         "name": "NASA Infrared Telescope Facility",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.826218316667,
+        "latitude": 19.826218316666665,
         "elevation_unit": "meter",
-        "longitude": -155.47199878889,
-        "timezone": "Pacific/Honolulu",
-        "aliases": []
+        "longitude": -155.4719987888889,
+        "timezone": "US/Aleutian",
+        "aliases": [
+             ""
+        ]
     },
     "lbt": {
         "source": "LBT website",
@@ -532,12 +519,12 @@
         "latitude_unit": "degree",
         "latitude": 32.7016,
         "elevation_unit": "meter",
-        "longitude": -109.8887,
-        "timezone": "America/Phoenix",
+        "longitude": 250.1281,
+        "timezone": "US/Mountain",
         "aliases": [
-            "Large Binocular Telescope",
-            "Mount Graham International Observatory",
-            "Mt Graham"
+             "Large Binocular Telescope",
+             "Mount Graham International Observatory",
+             "Mt Graham"
         ]
     },
     "salt": {
@@ -551,53 +538,53 @@
         "longitude": 20.810808,
         "timezone": "Africa/Johannesburg",
         "aliases": [
-            "SALT",
-            "Southern African Large Telescope",
-            "SAAO",
-            "Sutherland"
+             "SALT",
+             "Southern African Large Telescope",
+             "SAAO",
+             "Sutherland"
         ]
     },
     "srt": {
         "source": "SRT website & google maps",
-        "elevation": 650,
+        "elevation": 650.0,
         "name": "Sardinia Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 39.49304,
+        "latitude": 39.493040,
         "elevation_unit": "meter",
         "longitude": 9.24516,
-        "timezone": "Europe/Rome",
+        "timezone": "CET",
         "aliases": [
-            "SRT"
+             "SRT"
         ]
     },
     "medicina": {
         "source": "Medicina Radio Telescope website & google maps",
-        "elevation": 25,
+        "elevation": 25.0,
         "name": "Medicina Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 44.5205,
         "elevation_unit": "meter",
         "longitude": 11.6469,
-        "timezone": "Europe/Rome",
+        "timezone": "CET",
         "aliases": [
-            "Medicina Dish",
-            "Medicina"
+             "Medicina Dish",
+             "Medicina"
         ]
     },
     "noto": {
         "source": "Noto Radio Telescope website & google maps",
-        "elevation": 30,
+        "elevation": 30.0,
         "name": "Noto Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 36.87585,
         "elevation_unit": "meter",
         "longitude": 14.9889,
-        "timezone": "Europe/Rome",
+        "timezone": "CET",
         "aliases": [
-            "Noto"
+             "Noto"
         ]
     },
     "ohp": {
@@ -606,11 +593,13 @@
         "name": "Observatoire de Haute Provence",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 43.930833333333,
+        "latitude": 43.93083333333333,
         "elevation_unit": "meter",
-        "longitude": 5.7133333333333,
-        "timezone": "Europe/Paris",
-        "aliases": []
+        "longitude": 5.713333333333333,
+        "timezone": "CET",
+        "aliases": [
+             ""
+        ]
     },
     "sirene": {
         "source": "SIRENE website",
@@ -618,27 +607,28 @@
         "name": "Observatoire SIRENE",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 44,
+        "latitude": 44.0,
         "elevation_unit": "meter",
-        "longitude": 5.4869444444444,
-        "timezone": "Europe/Paris",
-        "aliases": []
+        "longitude": 5.486944444444444,
+        "timezone": "CET",
+        "aliases": [
+             ""
+        ]
     },
     "dct": {
         "source": "Site GPS on 20130708 UT as recorded in observatory wiki",
-        "elevation": 2337,
+        "elevation": 2337.0,
         "name": "Discovery Channel Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 34.744305,
         "elevation_unit": "meter",
-        "longitude": -111.422515,
+        "longitude": 248.577485,
         "aliases": [
-            "DCT",
-            "Discovery Channel Telescope",
-            "Happy Jack"
-        ],
-        "timezone": "America/Phoenix"
+             "DCT",
+             "Discovery Channel Telescope",
+             "Happy Jack"
+        ]
     },
     "vla": {
         "aliases": [
@@ -647,13 +637,12 @@
         ],
         "elevation": 2124,
         "elevation_unit": "meter",
-        "latitude": 34.078749166667,
+        "latitude": 34.07874916666667,
         "latitude_unit": "degree",
-        "longitude": -107.61828305556,
+        "longitude": -107.61828305555555,
         "longitude_unit": "degree",
-        "name": "Very Large Array",
-        "source": "wikipedia article",
-        "timezone": "America/Denver"
+        "name": "vla",
+        "source": "wikipedia article"
     },
     "alma": {
         "aliases": [
@@ -666,149 +655,37 @@
         "latitude_unit": "degree",
         "longitude": -67.755,
         "longitude_unit": "degree",
-        "name": "Atacama Large Millimeter Array",
-        "source": "https://almascience.eso.org/about-alma/alma-site",
-        "timezone": "America/Santiago"
+        "name": "alma",
+        "source": "https://almascience.eso.org/about-alma/alma-site"
     },
-    "elt": {
-        "aliases": [
-            "E-ELT"
-        ],
-        "elevation": 3060,
-        "elevation_unit": "meter",
-        "latitude": -24.5893,
-        "latitude_unit": "degree",
-        "longitude": -70.1916,
+    "tug": {
+        "source": "TUG Website: http://www.tug.tubitak.gov.tr/gozlemevi.php",
+        "elevation": 2500,
+        "name": "TÜBİTAK National Observatory",
         "longitude_unit": "degree",
-        "name": "European Extremely Large Telescope",
-        "timezone": "America/Santiago",
-        "source": "http://www.eso.org/sci/facilities/eelt/site/index.html"
+        "latitude_unit": "degree",
+        "latitude": 36.824166,
+        "elevation_unit": "meter",
+        "longitude": 30.335555,
+        "timezone": "Europe/Istanbul",
+        "aliases": [
+             "TUG"
+        ]
     },
-    "jodrell": {
-        "aliases": [
-            "Lovell Telescope"
-        ],
-        "elevation": 89,
-        "elevation_unit": "meter",
-        "latitude": 53.2368,
-        "latitude_unit": "degree",
-        "longitude": -2.3085,
-        "longitude_unit": "degree",
-        "name": "Jodrell Bank Observatory",
-        "timezone": "Europe/London",
-        "source": "Google maps"
-    },
-    "effelsberg": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 328,
-        "elevation_unit": "meter",
-        "latitude": 50.5251,
-        "latitude_unit": "degree",
-        "longitude": 6.8831,
-        "longitude_unit": "degree",
-        "name": "Effelsberg 100m telescope",
-        "timezone": "Europe/Berlin",
-        "source": "Google maps"
-    },
-    "atca": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 209,
-        "elevation_unit": "meter",
-        "latitude": -30.3128,
-        "latitude_unit": "degree",
-        "longitude": 149.565,
-        "longitude_unit": "degree",
-        "name": "Australia Telescope Compact Array",
-        "timezone": "Australia/Sydney",
-        "source": "Google maps"
-    },
-    "lmt": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 4563,
-        "elevation_unit": "meter",
-        "latitude": 18.9862,
-        "latitude_unit": "degree",
-        "longitude": -97.3148,
-        "longitude_unit": "degree",
-        "name": "Large Millimeter Telescope",
-        "timezone": "America/Mexico_City",
-        "source": "Google maps"
-    },
-    "pdb": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 2551,
-        "elevation_unit": "meter",
-        "latitude": 44.6342,
-        "latitude_unit": "degree",
-        "longitude": 5.908,
-        "longitude_unit": "degree",
-        "name": "Plateau de Bure Interferometer",
-        "timezone": "Europe/Paris",
-        "source": "Google maps"
-    },
-    "iram": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 2843,
-        "elevation_unit": "meter",
-        "latitude": 37.0664,
-        "latitude_unit": "degree",
-        "longitude": -3.3924,
-        "longitude_unit": "degree",
-        "name": "IRAM 30m telescope",
-        "timezone": "Europe/Madrid",
-        "source": "Google maps"
-    },
-    "teide": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 2390,
-        "elevation_unit": "meter",
-        "latitude": 28.3011,
-        "latitude_unit": "degree",
-        "longitude": -16.5107,
-        "longitude_unit": "degree",
-        "name": "Teide Observatory",
-        "timezone": "Atlantic/Canary",
-        "source": "http://www.iac.es, refined with Google maps"
-    },
-    "gbo": {
-        "aliases": [
-            "NRAO",
-            "Robert C. Byrd Telescope"
-        ],
-        "elevation": 806,
-        "elevation_unit": "meter",
-        "latitude": 38.4332,
-        "latitude_unit": "degree",
-        "longitude": -79.8397,
-        "longitude_unit": "degree",
-        "name": "Green Bank Observatory",
-        "timezone": "America/New_York",
-        "source": "Google maps"
-    },
-    "arecibo": {
-        "aliases": [
-            ""
-        ],
-        "elevation": 238,
-        "elevation_unit": "meter",
-        "latitude": 18.3442,
-        "latitude_unit": "degree",
-        "longitude": -66.7527,
-        "longitude_unit": "degree",
-        "name": "Arecibo Observatory",
-        "timezone": "America/Puerto_Rico",
-        "source": "Google maps"
+    "gbt": {
+    "aliases": [
+        "Green Bank Telescope",
+        "GBT"
+    ],
+    "elevation": 0,
+    "elevation_unit": "meter",
+    "latitude": 38.433056,
+    "latitude_unit": "degree",
+    "longitude": -79.839722,
+    "longitude_unit": "degree",
+    "elevation": 807,
+    "elevation_unit": "meter",
+    "name": "gbt",
+    "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation"
     }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -8,7 +8,7 @@
         "latitude": 51.477811,
         "elevation_unit": "meter",
         "longitude": -0.001475,
-        "timezone": "Greenwich",
+        "timezone": "Europe/London",
         "aliases": [
             "example_site"
         ]
@@ -19,9 +19,9 @@
         "name": "Mount Wilson Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 34.222579805555554,
+        "latitude": 34.222579805556,
         "elevation_unit": "meter",
-        "longitude": -118.06168400000001,
+        "longitude": -118.061684,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "CHARA"
@@ -33,10 +33,10 @@
         "name": "Observatorio Astronomico Nacional, Tonantzintla",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.032777777777778,
+        "latitude": 19.032777777778,
         "elevation_unit": "meter",
-        "longitude": 261.68611111111113,
-        "timezone": "US/Central",
+        "longitude": 261.68611111111,
+        "timezone": "America/Mexico_City",
         "aliases": [
             "Observatorio Astronomico Nacional, Tonantzintla"
         ]
@@ -47,10 +47,10 @@
         "name": "Lick Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 37.343333333333334,
+        "latitude": 37.343333333333,
         "elevation_unit": "meter",
-        "longitude": 238.36333333333332,
-        "timezone": "US/Pacific",
+        "longitude": 238.36333333333,
+        "timezone": "America/Los_Angeles",
         "aliases": [
             "Lick Observatory"
         ]
@@ -63,8 +63,8 @@
         "latitude_unit": "degree",
         "latitude": 31.95,
         "elevation_unit": "meter",
-        "longitude": 248.38333333333333,
-        "timezone": "US/Mountain",
+        "longitude": 248.38333333333,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Michigan-Dartmouth-MIT Observatory"
         ]
@@ -75,7 +75,7 @@
         "name": "Roque de los Muchachos, La Palma",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 28.758333333333333,
+        "latitude": 28.758333333333,
         "elevation_unit": "meter",
         "longitude": 342.12,
         "timezone": "Atlantic/Canary",
@@ -89,10 +89,10 @@
         "name": "Cerro Tololo Interamerican Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.165277777777778,
+        "latitude": -30.165277777778,
         "elevation_unit": "meter",
         "longitude": 289.185,
-        "timezone": "Chile/Continental",
+        "timezone": "America/Santiago",
         "aliases": [
             "Cerro Tololo Interamerican Observatory",
             "Cerro Tololo"
@@ -106,8 +106,8 @@
         "latitude_unit": "degree",
         "latitude": 32.78,
         "elevation_unit": "meter",
-        "longitude": 254.17999999999998,
-        "timezone": "US/Mountain",
+        "longitude": 254.18,
+        "timezone": "America/Denver",
         "aliases": [
             "Apache Point Observatory",
             "Apache Point"
@@ -119,7 +119,7 @@
         "name": "Beijing XingLong Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.39333333333333,
+        "latitude": 40.393333333333,
         "elevation_unit": "meter",
         "longitude": 117.575,
         "timezone": "Asia/Shanghai",
@@ -133,10 +133,10 @@
         "name": "McDonald Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 30.671666694444447,
+        "latitude": 30.671666694444,
         "elevation_unit": "meter",
-        "longitude": 255.97833330555557,
-        "timezone": "US/Central",
+        "longitude": 255.97833330556,
+        "timezone": "America/Chicago",
         "aliases": [
             "McDonald Observatory"
         ]
@@ -147,10 +147,10 @@
         "name": "Catalina Observatory: 61 inch telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 32.416666666666664,
+        "latitude": 32.416666666667,
         "elevation_unit": "meter",
-        "longitude": 249.26833333333335,
-        "timezone": "US/Mountain",
+        "longitude": 249.26833333333,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Catalina Observatory"
         ]
@@ -163,7 +163,7 @@
         "latitude_unit": "degree",
         "latitude": -35.32065,
         "elevation_unit": "meter",
-        "longitude": 149.02433333333335,
+        "longitude": 149.02433333333,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Mt. Stromlo Observatory"
@@ -175,10 +175,10 @@
         "name": "La Silla Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.256666666666668,
+        "latitude": -29.256666666667,
         "elevation_unit": "meter",
         "longitude": 289.27,
-        "timezone": "Chile/Continental",
+        "timezone": "America/Santiago",
         "aliases": [
             "La Silla Observatory"
         ]
@@ -192,7 +192,7 @@
         "latitude": -24.6252,
         "elevation_unit": "meter",
         "longitude": 289.597,
-        "timezone": "Chile/Continental",
+        "timezone": "America/Santiago",
         "aliases": [
             "Cerro Paranal",
             "Paranal Observatory"
@@ -204,10 +204,10 @@
         "name": "Canada-France-Hawaii Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.826666666666668,
+        "latitude": 19.826666666667,
         "elevation_unit": "meter",
-        "longitude": 204.52833333333334,
-        "timezone": "US/Aleutian",
+        "longitude": 204.52833333333,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "Canada-France-Hawaii Telescope"
         ]
@@ -218,10 +218,10 @@
         "name": "Lowell Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 35.09666666666667,
+        "latitude": 35.096666666667,
         "elevation_unit": "meter",
-        "longitude": 248.46499999999997,
-        "timezone": "US/Mountain",
+        "longitude": 248.465,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Lowell Observatory"
         ]
@@ -232,10 +232,10 @@
         "name": "W. M. Keck Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.828333333333333,
+        "latitude": 19.828333333333,
         "elevation_unit": "meter",
-        "longitude": 204.52166666666668,
-        "timezone": "US/Aleutian",
+        "longitude": 204.52166666667,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "W. M. Keck Observatory",
             "Keck Observatory"
@@ -250,7 +250,7 @@
         "latitude": 33.356,
         "elevation_unit": "meter",
         "longitude": 243.137,
-        "timezone": "US/Pacific",
+        "timezone": "America/Los_Angeles",
         "aliases": [
             "Hale Telescope"
         ]
@@ -261,10 +261,10 @@
         "name": "Multiple Mirror Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.688333333333333,
+        "latitude": 31.688333333333,
         "elevation_unit": "meter",
-        "longitude": 249.11499999999998,
-        "timezone": "US/Mountain",
+        "longitude": 249.115,
+        "timezone": "America/Phoenix",
         "aliases": [
             "Multiple Mirror Telescope"
         ]
@@ -275,10 +275,10 @@
         "name": "Dominion Astrophysical Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 48.52166666666667,
+        "latitude": 48.521666666667,
         "elevation_unit": "meter",
-        "longitude": 236.58333333333334,
-        "timezone": "US/Pacific",
+        "longitude": 236.58333333333,
+        "timezone": "America/Vancouver",
         "aliases": [
             "Dominion Astrophysical Observatory"
         ]
@@ -289,10 +289,10 @@
         "name": "Black Moshannon Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.92166666666667,
+        "latitude": 40.921666666667,
         "elevation_unit": "meter",
         "longitude": 281.995,
-        "timezone": "US/Eastern",
+        "timezone": "America/New_York",
         "aliases": [
             "Black Moshannon Observatory"
         ]
@@ -303,9 +303,9 @@
         "name": "Siding Spring Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -31.27336111111111,
+        "latitude": -31.273361111111,
         "elevation_unit": "meter",
-        "longitude": 149.06119444444445,
+        "longitude": 149.06119444444,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Siding Spring Observatory"
@@ -317,10 +317,10 @@
         "name": "Las Campanas Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.003333333333334,
+        "latitude": -29.003333333333,
         "elevation_unit": "meter",
-        "longitude": 289.29833333333335,
-        "timezone": "Chile/Continental",
+        "longitude": 289.29833333333,
+        "timezone": "America/Santiago",
         "aliases": [
             "Las Campanas Observatory"
         ]
@@ -331,10 +331,10 @@
         "name": "Kitt Peak National Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.96333333333333,
+        "latitude": 31.963333333333,
         "elevation_unit": "meter",
         "longitude": 248.4,
-        "timezone": "US/Mountain",
+        "timezone": "America/Phoenix",
         "aliases": [
             "Kitt Peak",
             "Kitt Peak National Observatory"
@@ -346,9 +346,9 @@
         "name": "Anglo-Australian Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -31.27703888888889,
+        "latitude": -31.277038888889,
         "elevation_unit": "meter",
-        "longitude": 149.06608611111113,
+        "longitude": 149.06608611111,
         "timezone": "Australia/Sydney",
         "aliases": [
             "Anglo-Australian Observatory"
@@ -360,10 +360,10 @@
         "name": "Whipple Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.680944444444446,
+        "latitude": 31.680944444444,
         "elevation_unit": "meter",
         "longitude": 249.1225,
-        "timezone": "US/Mountain",
+        "timezone": "America/Phoenix",
         "aliases": [
             "Whipple",
             "Whipple Observatory"
@@ -375,10 +375,10 @@
         "name": "Mt. Ekar 182 cm. Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 45.84858888888889,
+        "latitude": 45.848588888889,
         "elevation_unit": "meter",
-        "longitude": 11.581133333333334,
-        "timezone": "CET",
+        "longitude": 11.581133333333,
+        "timezone": "Europe/Rome",
         "aliases": [
             "Mt. Ekar 182 cm. Telescope"
         ]
@@ -389,10 +389,10 @@
         "name": "Subaru Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.825555555555557,
+        "latitude": 19.825555555556,
         "elevation_unit": "meter",
-        "longitude": 204.5238888888889,
-        "timezone": "US/Aleutian",
+        "longitude": 204.52388888889,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "Subaru Telescope"
         ]
@@ -419,7 +419,7 @@
         "latitude_unit": "degree",
         "latitude": 8.79,
         "elevation_unit": "meter",
-        "longitude": 289.1333333333333,
+        "longitude": 289.13333333333,
         "timezone": "America/Caracas",
         "aliases": [
             "National Observatory of Venezuela"
@@ -431,10 +431,10 @@
         "name": "Observatorio Astronomico Nacional, San Pedro Martir",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.029166666666665,
+        "latitude": 31.029166666667,
         "elevation_unit": "meter",
-        "longitude": 244.51305555555555,
-        "timezone": "US/Pacific",
+        "longitude": 244.51305555556,
+        "timezone": "America/Tijuana",
         "aliases": [
             "Observatorio Astronomico Nacional, San Pedro Martir"
         ]
@@ -448,7 +448,7 @@
         "latitude": 46.9528,
         "latitude_unit": "degree",
         "longitude": -120.7278,
-        "timezone": "US/Pacific",
+        "timezone": "America/Los_Angeles",
         "longitude_unit": "degree",
         "name": "Manastash Ridge Observatory",
         "source": "MRO website"
@@ -462,7 +462,7 @@
         "latitude": 20.71552,
         "elevation_unit": "meter",
         "longitude": 203.831,
-        "timezone": "US/Aleutian",
+        "timezone": "Pacific/Honolulu",
         "aliases": [
             "Haleakala Observatories"
         ]
@@ -473,14 +473,14 @@
         "name": "Gemini South",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.24074166666667,
+        "latitude": -30.240741666667,
         "elevation_unit": "meter",
-        "longitude": 289.2633166666667,
-        "timezone": "Chile/Continental",
+        "longitude": 289.26331666667,
+        "timezone": "America/Santiago",
         "aliases": [
-             "Cerro Pachon",
-             "Gemini South",
-             "gems"
+            "Cerro Pachon",
+            "Gemini South",
+            "gems"
         ]
     },
     "gemini_north": {
@@ -489,12 +489,12 @@
         "name": "Gemini North",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.823801447222223,
+        "latitude": 19.823801447222,
         "elevation_unit": "meter",
-        "longitude": -155.4690467527778,
-        "timezone": "US/Aleutian",
+        "longitude": -155.46904675278,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
-             "gemn"
+            "gemn"
         ]
     },
     "irtf": {
@@ -503,12 +503,12 @@
         "name": "NASA Infrared Telescope Facility",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 19.826218316666665,
+        "latitude": 19.826218316667,
         "elevation_unit": "meter",
-        "longitude": -155.4719987888889,
-        "timezone": "US/Aleutian",
+        "longitude": -155.47199878889,
+        "timezone": "Pacific/Honolulu",
         "aliases": [
-             ""
+            ""
         ]
     },
     "lbt": {
@@ -520,11 +520,11 @@
         "latitude": 32.7016,
         "elevation_unit": "meter",
         "longitude": 250.1281,
-        "timezone": "US/Mountain",
+        "timezone": "America/Phoenix",
         "aliases": [
-             "Large Binocular Telescope",
-             "Mount Graham International Observatory",
-             "Mt Graham"
+            "Large Binocular Telescope",
+            "Mount Graham International Observatory",
+            "Mt Graham"
         ]
     },
     "salt": {
@@ -538,53 +538,53 @@
         "longitude": 20.810808,
         "timezone": "Africa/Johannesburg",
         "aliases": [
-             "SALT",
-             "Southern African Large Telescope",
-             "SAAO",
-             "Sutherland"
+            "SALT",
+            "Southern African Large Telescope",
+            "SAAO",
+            "Sutherland"
         ]
     },
     "srt": {
         "source": "SRT website & google maps",
-        "elevation": 650.0,
+        "elevation": 650,
         "name": "Sardinia Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 39.493040,
+        "latitude": 39.49304,
         "elevation_unit": "meter",
         "longitude": 9.24516,
-        "timezone": "CET",
+        "timezone": "Europe/Rome",
         "aliases": [
-             "SRT"
+            "SRT"
         ]
     },
     "medicina": {
         "source": "Medicina Radio Telescope website & google maps",
-        "elevation": 25.0,
+        "elevation": 25,
         "name": "Medicina Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 44.5205,
         "elevation_unit": "meter",
         "longitude": 11.6469,
-        "timezone": "CET",
+        "timezone": "Europe/Rome",
         "aliases": [
-             "Medicina Dish",
-             "Medicina"
+            "Medicina Dish",
+            "Medicina"
         ]
     },
     "noto": {
         "source": "Noto Radio Telescope website & google maps",
-        "elevation": 30.0,
+        "elevation": 30,
         "name": "Noto Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 36.87585,
         "elevation_unit": "meter",
         "longitude": 14.9889,
-        "timezone": "CET",
+        "timezone": "Europe/Rome",
         "aliases": [
-             "Noto"
+            "Noto"
         ]
     },
     "ohp": {
@@ -593,12 +593,12 @@
         "name": "Observatoire de Haute Provence",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 43.93083333333333,
+        "latitude": 43.930833333333,
         "elevation_unit": "meter",
-        "longitude": 5.713333333333333,
-        "timezone": "CET",
+        "longitude": 5.7133333333333,
+        "timezone": "Europe/Paris",
         "aliases": [
-             ""
+            ""
         ]
     },
     "sirene": {
@@ -607,17 +607,17 @@
         "name": "Observatoire SIRENE",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 44.0,
+        "latitude": 44,
         "elevation_unit": "meter",
-        "longitude": 5.486944444444444,
-        "timezone": "CET",
+        "longitude": 5.4869444444444,
+        "timezone": "Europe/Paris",
         "aliases": [
-             ""
+            ""
         ]
     },
     "dct": {
         "source": "Site GPS on 20130708 UT as recorded in observatory wiki",
-        "elevation": 2337.0,
+        "elevation": 2337,
         "name": "Discovery Channel Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
@@ -625,10 +625,11 @@
         "elevation_unit": "meter",
         "longitude": 248.577485,
         "aliases": [
-             "DCT",
-             "Discovery Channel Telescope",
-             "Happy Jack"
-        ]
+            "DCT",
+            "Discovery Channel Telescope",
+            "Happy Jack"
+        ],
+        "timezone": "America/Phoenix"
     },
     "vla": {
         "aliases": [
@@ -637,12 +638,13 @@
         ],
         "elevation": 2124,
         "elevation_unit": "meter",
-        "latitude": 34.07874916666667,
+        "latitude": 34.078749166667,
         "latitude_unit": "degree",
-        "longitude": -107.61828305555555,
+        "longitude": -107.61828305556,
         "longitude_unit": "degree",
         "name": "vla",
-        "source": "wikipedia article"
+        "source": "wikipedia article",
+        "timezone": "America/Denver"
     },
     "alma": {
         "aliases": [
@@ -656,12 +658,13 @@
         "longitude": -67.755,
         "longitude_unit": "degree",
         "name": "alma",
-        "source": "https://almascience.eso.org/about-alma/alma-site"
+        "source": "https://almascience.eso.org/about-alma/alma-site",
+        "timezone": "America/Santiago"
     },
     "tug": {
         "source": "TUG Website: http://www.tug.tubitak.gov.tr/gozlemevi.php",
         "elevation": 2500,
-        "name": "TÜBİTAK National Observatory",
+        "name": "T\u00dcB\u0130TAK National Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 36.824166,
@@ -669,23 +672,22 @@
         "longitude": 30.335555,
         "timezone": "Europe/Istanbul",
         "aliases": [
-             "TUG"
+            "TUG"
         ]
     },
     "gbt": {
-    "aliases": [
-        "Green Bank Telescope",
-        "GBT"
-    ],
-    "elevation": 0,
-    "elevation_unit": "meter",
-    "latitude": 38.433056,
-    "latitude_unit": "degree",
-    "longitude": -79.839722,
-    "longitude_unit": "degree",
-    "elevation": 807,
-    "elevation_unit": "meter",
-    "name": "gbt",
-    "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation"
+        "aliases": [
+            "Green Bank Telescope",
+            "GBT"
+        ],
+        "elevation": 807,
+        "elevation_unit": "meter",
+        "latitude": 38.433056,
+        "latitude_unit": "degree",
+        "longitude": -79.839722,
+        "longitude_unit": "degree",
+        "name": "gbt",
+        "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation",
+        "timezone": "America/New_York"
     }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -10,7 +10,7 @@
         "longitude": -0.001475,
         "timezone": "Europe/London",
         "aliases": [
-            "example_site"
+            "ROG"
         ]
     },
     "mwo": {
@@ -80,7 +80,13 @@
         "longitude": -17.88,
         "timezone": "Atlantic/Canary",
         "aliases": [
-            "Roque de los Muchachos"
+            "Roque de los Muchachos",
+            "Isaac Newton group",
+            "ING",
+            "William Herschel Telescope",
+            "WHT",
+            "Grantecan",
+            "GTC"
         ]
     },
     "ctio": {
@@ -124,7 +130,8 @@
         "longitude": 117.5759,
         "timezone": "Asia/Shanghai",
         "aliases": [
-            "Beijing XingLong Observatory"
+            "Beijing XingLong Observatory",
+            "LAMOST"
         ]
     },
     "mcdonald": {
@@ -152,7 +159,8 @@
         "longitude": -110.73166666667,
         "timezone": "America/Phoenix",
         "aliases": [
-            "Catalina Observatory"
+            "Catalina Observatory",
+            "Mount Bigelow"
         ]
     },
     "mso": {
@@ -180,7 +188,9 @@
         "longitude": -70.7338,
         "timezone": "America/Santiago",
         "aliases": [
-            "La Silla Observatory"
+            "La Silla Observatory",
+            "NTT",
+            "ESO 3.6m"
         ]
     },
     "paranal": {
@@ -195,7 +205,12 @@
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Paranal",
-            "Paranal Observatory"
+            "Paranal Observatory",
+            "Very Large Telescope",
+            "VLT",
+            "VST",
+            "VISTA",
+            "NGST"
         ]
     },
     "cfht": {
@@ -507,9 +522,7 @@
         "elevation_unit": "meter",
         "longitude": -155.47199878889,
         "timezone": "Pacific/Honolulu",
-        "aliases": [
-            ""
-        ]
+        "aliases": []
     },
     "lbt": {
         "source": "LBT website",
@@ -597,9 +610,7 @@
         "elevation_unit": "meter",
         "longitude": 5.7133333333333,
         "timezone": "Europe/Paris",
-        "aliases": [
-            ""
-        ]
+        "aliases": []
     },
     "sirene": {
         "source": "SIRENE website",
@@ -611,9 +622,7 @@
         "elevation_unit": "meter",
         "longitude": 5.4869444444444,
         "timezone": "Europe/Paris",
-        "aliases": [
-            ""
-        ]
+        "aliases": []
     },
     "dct": {
         "source": "Site GPS on 20130708 UT as recorded in observatory wiki",

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -19,9 +19,9 @@
         "name": "Mount Wilson Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 34.222579805556,
+        "latitude": 34.2259,
         "elevation_unit": "meter",
-        "longitude": -118.061684,
+        "longitude": -118.057,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "CHARA"
@@ -89,9 +89,9 @@
         "name": "Cerro Tololo Interamerican Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.165277777778,
+        "latitude": -30.169,
         "elevation_unit": "meter",
-        "longitude": -70.815,
+        "longitude": -70.8062,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Tololo Interamerican Observatory",
@@ -119,9 +119,9 @@
         "name": "Beijing XingLong Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.393333333333,
+        "latitude": 40.3957,
         "elevation_unit": "meter",
-        "longitude": 117.575,
+        "longitude": 117.5759,
         "timezone": "Asia/Shanghai",
         "aliases": [
             "Beijing XingLong Observatory"
@@ -175,9 +175,9 @@
         "name": "La Silla Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.256666666667,
+        "latitude": -29.259,
         "elevation_unit": "meter",
-        "longitude": -70.73,
+        "longitude": -70.7338,
         "timezone": "America/Santiago",
         "aliases": [
             "La Silla Observatory"
@@ -189,9 +189,9 @@
         "name": "Paranal Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -24.6252,
+        "latitude": -24.6275,
         "elevation_unit": "meter",
-        "longitude": -70.403,
+        "longitude": -70.4045,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Paranal",
@@ -317,9 +317,9 @@
         "name": "Las Campanas Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.003333333333,
+        "latitude": -29.0142,
         "elevation_unit": "meter",
-        "longitude": -70.701666666667,
+        "longitude": -70.6925,
         "timezone": "America/Santiago",
         "aliases": [
             "Las Campanas Observatory"
@@ -491,7 +491,7 @@
         "latitude_unit": "degree",
         "latitude": 19.823801447222,
         "elevation_unit": "meter",
-        "longitude": 155.46904675278,
+        "longitude": -155.46904675278,
         "timezone": "Pacific/Honolulu",
         "aliases": [
             "gemn"
@@ -505,7 +505,7 @@
         "latitude_unit": "degree",
         "latitude": 19.826218316667,
         "elevation_unit": "meter",
-        "longitude": 155.47199878889,
+        "longitude": -155.47199878889,
         "timezone": "Pacific/Honolulu",
         "aliases": [
             ""
@@ -519,7 +519,7 @@
         "latitude_unit": "degree",
         "latitude": 32.7016,
         "elevation_unit": "meter",
-        "longitude": -109.8719,
+        "longitude": -109.8887,
         "timezone": "America/Phoenix",
         "aliases": [
             "Large Binocular Telescope",

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -244,7 +244,7 @@
     "Palomar": {
         "source": "IRAF Observatory Database",
         "elevation": 1706,
-        "name": "The Hale Telescope",
+        "name": "Hale Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 33.356,
@@ -343,7 +343,7 @@
     "aao": {
         "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 1164,
-        "name": "Anglo-Australian Observatory",
+        "name": "Australian Astronomical Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": -31.277038888889,
@@ -642,7 +642,7 @@
         "latitude_unit": "degree",
         "longitude": -107.61828305556,
         "longitude_unit": "degree",
-        "name": "vla",
+        "name": "Very Large Array",
         "source": "wikipedia article, refined using Google Maps",
         "timezone": "America/Denver"
     },
@@ -657,7 +657,7 @@
         "latitude_unit": "degree",
         "longitude": -67.755,
         "longitude_unit": "degree",
-        "name": "alma",
+        "name": "Atacama Large Millimeter Array",
         "source": "https://almascience.eso.org/about-alma/alma-site",
         "timezone": "America/Santiago"
     },
@@ -686,7 +686,7 @@
         "latitude_unit": "degree",
         "longitude": -79.8397,
         "longitude_unit": "degree",
-        "name": "gbt",
+        "name": "Green Bank Observatory",
         "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation, refined using Google Maps",
         "timezone": "America/New_York"
     }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -29,7 +29,7 @@
     },
     "tona": {
         "source": "IRAF Observatory Database, refined using Google Maps",
-        "elevation": 0,
+        "elevation": 2174,
         "name": "Observatorio Astronomico Nacional, Tonantzintla",
         "longitude_unit": "degree",
         "latitude_unit": "degree",

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -244,7 +244,7 @@
     "Palomar": {
         "source": "IRAF Observatory Database",
         "elevation": 1706,
-        "name": "The Hale Telescope",
+        "name": "Hale Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 33.356,
@@ -343,7 +343,7 @@
     "aao": {
         "source": "IRAF Observatory Database",
         "elevation": 1164,
-        "name": "Anglo-Australian Observatory",
+        "name": "Australian Astronomical Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": -31.277038888889,
@@ -642,7 +642,7 @@
         "latitude_unit": "degree",
         "longitude": -107.61828305556,
         "longitude_unit": "degree",
-        "name": "vla",
+        "name": "Very Large Array",
         "source": "wikipedia article",
         "timezone": "America/Denver"
     },
@@ -657,7 +657,7 @@
         "latitude_unit": "degree",
         "longitude": -67.755,
         "longitude_unit": "degree",
-        "name": "alma",
+        "name": "Atacama Large Millimeter Array",
         "source": "https://almascience.eso.org/about-alma/alma-site",
         "timezone": "America/Santiago"
     }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -689,5 +689,206 @@
         "name": "Green Bank Observatory",
         "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation, refined using Google Maps",
         "timezone": "America/New_York"
+    },
+    "elt": {
+        "aliases": [
+            "E-ELT"
+        ],
+        "elevation": 3060,
+        "elevation_unit": "meter",
+        "latitude": -24.5893,
+        "latitude_unit": "degree",
+        "longitude": -70.1916,
+        "longitude_unit": "degree",
+        "name": "European Extremely Large Telescope",
+        "timezone": "America/Santiago",
+        "source": "http://www.eso.org/sci/facilities/eelt/site/index.html"
+    },
+    "jodrell": {
+        "aliases": [
+            "Lovell Telescope"
+        ],
+        "elevation": 89,
+        "elevation_unit": "meter",
+        "latitude": 53.2368,
+        "latitude_unit": "degree",
+        "longitude": -2.3085,
+        "longitude_unit": "degree",
+        "name": "Jodrell Bank Observatory",
+        "timezone": "Europe/London",
+        "source": "Google maps"
+    },
+    "effelsberg": {
+        "aliases": [],
+        "elevation": 328,
+        "elevation_unit": "meter",
+        "latitude": 50.5251,
+        "latitude_unit": "degree",
+        "longitude": 6.8831,
+        "longitude_unit": "degree",
+        "name": "Effelsberg 100m telescope",
+        "timezone": "Europe/Berlin",
+        "source": "Google maps"
+    },
+    "atca": {
+        "aliases": [],
+        "elevation": 209,
+        "elevation_unit": "meter",
+        "latitude": -30.3128,
+        "latitude_unit": "degree",
+        "longitude": 149.565,
+        "longitude_unit": "degree",
+        "name": "Australia Telescope Compact Array",
+        "timezone": "Australia/Sydney",
+        "source": "Google maps"
+    },
+    "lmt": {
+        "aliases": [],
+        "elevation": 4563,
+        "elevation_unit": "meter",
+        "latitude": 18.9862,
+        "latitude_unit": "degree",
+        "longitude": -97.3148,
+        "longitude_unit": "degree",
+        "name": "Large Millimeter Telescope",
+        "timezone": "America/Mexico_City",
+        "source": "Google maps"
+    },
+    "pdb": {
+        "aliases": [],
+        "elevation": 2551,
+        "elevation_unit": "meter",
+        "latitude": 44.6342,
+        "latitude_unit": "degree",
+        "longitude": 5.908,
+        "longitude_unit": "degree",
+        "name": "Plateau de Bure Interferometer",
+        "timezone": "Europe/Paris",
+        "source": "Google maps"
+    },
+    "iram": {
+        "aliases": [],
+        "elevation": 2843,
+        "elevation_unit": "meter",
+        "latitude": 37.0664,
+        "latitude_unit": "degree",
+        "longitude": -3.3924,
+        "longitude_unit": "degree",
+        "name": "IRAM 30m telescope",
+        "timezone": "Europe/Madrid",
+        "source": "Google maps"
+    },
+    "teide": {
+        "aliases": [],
+        "elevation": 2390,
+        "elevation_unit": "meter",
+        "latitude": 28.3011,
+        "latitude_unit": "degree",
+        "longitude": -16.5107,
+        "longitude_unit": "degree",
+        "name": "Teide Observatory",
+        "timezone": "Atlantic/Canary",
+        "source": "http://www.iac.es, refined with Google maps"
+    },
+    "arecibo": {
+        "aliases": [],
+        "elevation": 238,
+        "elevation_unit": "meter",
+        "latitude": 18.3442,
+        "latitude_unit": "degree",
+        "longitude": -66.7527,
+        "longitude_unit": "degree",
+        "name": "Arecibo Observatory",
+        "timezone": "America/Puerto_Rico",
+        "source": "Google maps"
+    },
+    "spt": {
+        "aliases": [],
+        "elevation": 0,
+        "elevation_unit": "meter",
+        "latitude": -90,
+        "latitude_unit": "degree",
+        "longitude": 180,
+        "longitude_unit": "degree",
+        "name": "South Pole Telescope",
+        "timezone": "Antarctica/South_Pole",
+        "source": "Google maps"
+    },
+    "onsala": {
+        "aliases": [],
+        "elevation": 18,
+        "elevation_unit": "meter",
+        "latitude": 57.393056,
+        "latitude_unit": "degree",
+        "longitude": 11.91772,
+        "longitude_unit": "degree",
+        "name": "Onsala Space Observatory",
+        "timezone": "Europe/Stockholm",
+        "source": "Google maps"
+    },
+    "fast": {
+        "aliases": [],
+        "elevation": 853,
+        "elevation_unit": "meter",
+        "latitude": 25.6529,
+        "latitude_unit": "degree",
+        "longitude": 106.85661,
+        "longitude_unit": "degree",
+        "name": "500m-aperture Spherical Telescope",
+        "timezone": "Asia/Shanghai",
+        "source": "Google maps"
+    },
+    "nobeyama": {
+        "aliases": [],
+        "elevation": 1347,
+        "elevation_unit": "meter",
+        "latitude": 35.94452,
+        "latitude_unit": "degree",
+        "longitude": 138.47242,
+        "longitude_unit": "degree",
+        "name": "Nobeyama 45m Telescope",
+        "timezone": "Asia/Tokyo",
+        "source": "Google maps"
+    },
+    "uclo": {
+        "aliases": [
+            "University of London Observatory",
+            "ULO"
+        ],
+        "elevation": 77,
+        "elevation_unit": "meter",
+        "latitude": 51.61335,
+        "latitude_unit": "degree",
+        "longitude": -0.242255,
+        "longitude_unit": "degree",
+        "name": "University College London Observatory",
+        "timezone": "Europe/London",
+        "source": "Google maps"
+    },
+    "parkes": {
+        "aliases": [
+            "The Dish"
+        ],
+        "elevation": 378,
+        "elevation_unit": "meter",
+        "latitude": -32.99778,
+        "latitude_unit": "degree",
+        "longitude": 148.26292,
+        "longitude_unit": "degree",
+        "name": "Parkes 64m Telescope",
+        "timezone": "Australia/Sydney",
+        "source": "Google maps"
+    },
+    "calaralto": {
+        "aliases": [],
+        "elevation": 2158,
+        "elevation_unit": "meter",
+        "latitude": 37.223611,
+        "latitude_unit": "degree",
+        "longitude": -2.546111,
+        "longitude_unit": "degree",
+        "name": "Calar Alto",
+        "timezone": "Europe/Madrid",
+        "source": "Google maps"
     }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -14,21 +14,21 @@
         ]
     },
     "mwo": {
-        "source": "CHARA website",
+        "source": "CHARA website, refined using Google Maps",
         "elevation": 1742,
         "name": "Mount Wilson Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 34.222579805556,
+        "latitude": 34.2259,
         "elevation_unit": "meter",
-        "longitude": -118.061684,
+        "longitude": -118.057,
         "timezone": "America/Los_Angeles",
         "aliases": [
             "CHARA"
         ]
     },
     "tona": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 0,
         "name": "Observatorio Astronomico Nacional, Tonantzintla",
         "longitude_unit": "degree",
@@ -42,7 +42,7 @@
         ]
     },
     "lick": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 1290,
         "name": "Lick Observatory",
         "longitude_unit": "degree",
@@ -56,7 +56,7 @@
         ]
     },
     "mdm": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 1938,
         "name": "Michigan-Dartmouth-MIT Observatory",
         "longitude_unit": "degree",
@@ -70,7 +70,7 @@
         ]
     },
     "lapalma": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2327,
         "name": "Roque de los Muchachos, La Palma",
         "longitude_unit": "degree",
@@ -84,14 +84,14 @@
         ]
     },
     "ctio": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2215,
         "name": "Cerro Tololo Interamerican Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -30.165277777778,
+        "latitude": -30.169,
         "elevation_unit": "meter",
-        "longitude": -70.815,
+        "longitude": -70.8062,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Tololo Interamerican Observatory",
@@ -99,7 +99,7 @@
         ]
     },
     "apo": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2798,
         "name": "Apache Point Observatory",
         "longitude_unit": "degree",
@@ -114,21 +114,21 @@
         ]
     },
     "BAO": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 950,
         "name": "Beijing XingLong Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 40.393333333333,
+        "latitude": 40.3957,
         "elevation_unit": "meter",
-        "longitude": 117.575,
+        "longitude": 117.5759,
         "timezone": "Asia/Shanghai",
         "aliases": [
             "Beijing XingLong Observatory"
         ]
     },
     "mcdonald": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2075,
         "name": "McDonald Observatory",
         "longitude_unit": "degree",
@@ -142,7 +142,7 @@
         ]
     },
     "mtbigelow": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2510,
         "name": "Catalina Observatory: 61 inch telescope",
         "longitude_unit": "degree",
@@ -156,7 +156,7 @@
         ]
     },
     "mso": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 767,
         "name": "Mt. Stromlo Observatory",
         "longitude_unit": "degree",
@@ -170,28 +170,28 @@
         ]
     },
     "lasilla": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2347,
         "name": "La Silla Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.256666666667,
+        "latitude": -29.259,
         "elevation_unit": "meter",
-        "longitude": -70.73,
+        "longitude": -70.7338,
         "timezone": "America/Santiago",
         "aliases": [
             "La Silla Observatory"
         ]
     },
     "paranal": {
-        "source": "ESO webpage",
+        "source": "ESO webpage, refined using Google Maps",
         "elevation": 2635,
         "name": "Paranal Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -24.6252,
+        "latitude": -24.6275,
         "elevation_unit": "meter",
-        "longitude": -70.403,
+        "longitude": -70.4045,
         "timezone": "America/Santiago",
         "aliases": [
             "Cerro Paranal",
@@ -199,7 +199,7 @@
         ]
     },
     "cfht": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 4215,
         "name": "Canada-France-Hawaii Telescope",
         "longitude_unit": "degree",
@@ -213,7 +213,7 @@
         ]
     },
     "lowell": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2198,
         "name": "Lowell Observatory",
         "longitude_unit": "degree",
@@ -227,7 +227,7 @@
         ]
     },
     "keck": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 4160,
         "name": "W. M. Keck Observatory",
         "longitude_unit": "degree",
@@ -256,7 +256,7 @@
         ]
     },
     "mmt": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2608,
         "name": "Multiple Mirror Telescope",
         "longitude_unit": "degree",
@@ -270,7 +270,7 @@
         ]
     },
     "dao": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 229,
         "name": "Dominion Astrophysical Observatory",
         "longitude_unit": "degree",
@@ -284,7 +284,7 @@
         ]
     },
     "bmo": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 738,
         "name": "Black Moshannon Observatory",
         "longitude_unit": "degree",
@@ -298,7 +298,7 @@
         ]
     },
     "sso": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 1149,
         "name": "Siding Spring Observatory",
         "longitude_unit": "degree",
@@ -312,21 +312,21 @@
         ]
     },
     "lco": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2282,
         "name": "Las Campanas Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -29.003333333333,
+        "latitude": -29.0142,
         "elevation_unit": "meter",
-        "longitude": -70.701666666667,
+        "longitude": -70.6925,
         "timezone": "America/Santiago",
         "aliases": [
             "Las Campanas Observatory"
         ]
     },
     "kpno": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2120,
         "name": "Kitt Peak National Observatory",
         "longitude_unit": "degree",
@@ -341,7 +341,7 @@
         ]
     },
     "aao": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 1164,
         "name": "Anglo-Australian Observatory",
         "longitude_unit": "degree",
@@ -355,7 +355,7 @@
         ]
     },
     "flwo": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2320,
         "name": "Whipple Observatory",
         "longitude_unit": "degree",
@@ -370,7 +370,7 @@
         ]
     },
     "ekar": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 1413,
         "name": "Mt. Ekar 182 cm. Telescope",
         "longitude_unit": "degree",
@@ -384,7 +384,7 @@
         ]
     },
     "Subaru": {
-        "source": "Subaru Telescope website (August 2015)",
+        "source": "Subaru Telescope website (August 2015), refined using Google Maps",
         "elevation": 4139,
         "name": "Subaru Telescope",
         "longitude_unit": "degree",
@@ -412,7 +412,7 @@
         ]
     },
     "NOV": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 3610,
         "name": "National Observatory of Venezuela",
         "longitude_unit": "degree",
@@ -426,14 +426,14 @@
         ]
     },
     "spm": {
-        "source": "IRAF Observatory Database",
+        "source": "IRAF Observatory Database, refined using Google Maps",
         "elevation": 2830,
         "name": "Observatorio Astronomico Nacional, San Pedro Martir",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 31.029166666667,
+        "latitude": 31.044333,
         "elevation_unit": "meter",
-        "longitude": -115.48694444444,
+        "longitude": -115.46375,
         "timezone": "America/Tijuana",
         "aliases": [
             "Observatorio Astronomico Nacional, San Pedro Martir"
@@ -468,7 +468,7 @@
         ]
     },
     "gemini_south": {
-        "source": "CTIO Website",
+        "source": "CTIO Website, refined using Google Maps",
         "elevation": 2750,
         "name": "Gemini South",
         "longitude_unit": "degree",
@@ -484,7 +484,7 @@
         ]
     },
     "gemini_north": {
-        "source": "CTIO Website",
+        "source": "CTIO Website, refined using Google Maps",
         "elevation": 4213,
         "name": "Gemini North",
         "longitude_unit": "degree",
@@ -498,7 +498,7 @@
         ]
     },
     "irtf": {
-        "source": "IRTF Website",
+        "source": "IRTF Website, refined using Google Maps",
         "elevation": 4168,
         "name": "NASA Infrared Telescope Facility",
         "longitude_unit": "degree",
@@ -512,14 +512,14 @@
         ]
     },
     "lbt": {
-        "source": "LBT website",
+        "source": "LBT website, refined using Google Maps",
         "elevation": 2902,
         "name": "Large Binocular Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 32.7016,
         "elevation_unit": "meter",
-        "longitude": -109.8719,
+        "longitude": -109.8887,
         "timezone": "America/Phoenix",
         "aliases": [
             "Large Binocular Telescope",
@@ -588,7 +588,7 @@
         ]
     },
     "ohp": {
-        "source": "OHP website",
+        "source": "OHP website, refined using Google Maps",
         "elevation": 650,
         "name": "Observatoire de Haute Provence",
         "longitude_unit": "degree",
@@ -602,7 +602,7 @@
         ]
     },
     "sirene": {
-        "source": "SIRENE website",
+        "source": "SIRENE website, refined using Google Maps",
         "elevation": 1100,
         "name": "Observatoire SIRENE",
         "longitude_unit": "degree",
@@ -643,7 +643,7 @@
         "longitude": -107.61828305556,
         "longitude_unit": "degree",
         "name": "vla",
-        "source": "wikipedia article",
+        "source": "wikipedia article, refined using Google Maps",
         "timezone": "America/Denver"
     },
     "alma": {
@@ -682,12 +682,12 @@
         ],
         "elevation": 807,
         "elevation_unit": "meter",
-        "latitude": 38.433056,
+        "latitude": 38.4332,
         "latitude_unit": "degree",
-        "longitude": -79.839722,
+        "longitude": -79.8397,
         "longitude_unit": "degree",
         "name": "gbt",
-        "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation",
+        "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation, refined using Google Maps",
         "timezone": "America/New_York"
     }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -669,5 +669,146 @@
         "name": "Atacama Large Millimeter Array",
         "source": "https://almascience.eso.org/about-alma/alma-site",
         "timezone": "America/Santiago"
+    },
+    "elt": {
+        "aliases": [
+            "E-ELT"
+        ],
+        "elevation": 3060,
+        "elevation_unit": "meter",
+        "latitude": -24.5893,
+        "latitude_unit": "degree",
+        "longitude": -70.1916,
+        "longitude_unit": "degree",
+        "name": "European Extremely Large Telescope",
+        "timezone": "America/Santiago",
+        "source": "http://www.eso.org/sci/facilities/eelt/site/index.html"
+    },
+    "jodrell": {
+        "aliases": [
+            "Lovell Telescope"
+        ],
+        "elevation": 89,
+        "elevation_unit": "meter",
+        "latitude": 53.2368,
+        "latitude_unit": "degree",
+        "longitude": -2.3085,
+        "longitude_unit": "degree",
+        "name": "Jodrell Bank Observatory",
+        "timezone": "Europe/London",
+        "source": "Google maps"
+    },
+    "effelsberg": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 328,
+        "elevation_unit": "meter",
+        "latitude": 50.5251,
+        "latitude_unit": "degree",
+        "longitude": 6.8831,
+        "longitude_unit": "degree",
+        "name": "Effelsberg 100m telescope",
+        "timezone": "Europe/Berlin",
+        "source": "Google maps"
+    },
+    "atca": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 209,
+        "elevation_unit": "meter",
+        "latitude": -30.3128,
+        "latitude_unit": "degree",
+        "longitude": 149.565,
+        "longitude_unit": "degree",
+        "name": "Australia Telescope Compact Array",
+        "timezone": "Australia/Sydney",
+        "source": "Google maps"
+    },
+    "lmt": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 4563,
+        "elevation_unit": "meter",
+        "latitude": 18.9862,
+        "latitude_unit": "degree",
+        "longitude": -97.3148,
+        "longitude_unit": "degree",
+        "name": "Large Millimeter Telescope",
+        "timezone": "America/Mexico_City",
+        "source": "Google maps"
+    },
+    "pdb": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 2551,
+        "elevation_unit": "meter",
+        "latitude": 44.6342,
+        "latitude_unit": "degree",
+        "longitude": 5.908,
+        "longitude_unit": "degree",
+        "name": "Plateau de Bure Interferometer",
+        "timezone": "Europe/Paris",
+        "source": "Google maps"
+    },
+    "iram": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 2843,
+        "elevation_unit": "meter",
+        "latitude": 37.0664,
+        "latitude_unit": "degree",
+        "longitude": -3.3924,
+        "longitude_unit": "degree",
+        "name": "IRAM 30m telescope",
+        "timezone": "Europe/Madrid",
+        "source": "Google maps"
+    },
+    "teide": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 2390,
+        "elevation_unit": "meter",
+        "latitude": 28.3011,
+        "latitude_unit": "degree",
+        "longitude": -16.5107,
+        "longitude_unit": "degree",
+        "name": "Teide Observatory",
+        "timezone": "Atlantic/Canary",
+        "source": "http://www.iac.es, refined with Google maps"
+    },
+    "gbo": {
+        "aliases": [
+            "NRAO",
+            "Robert C. Byrd Telescope"
+        ],
+        "elevation": 806,
+        "elevation_unit": "meter",
+        "latitude": 38.4332,
+        "latitude_unit": "degree",
+        "longitude": -79.8397,
+        "longitude_unit": "degree",
+        "name": "Green Bank Observatory",
+        "timezone": "America/New_York",
+        "source": "Google maps"
+    },
+    "arecibo": {
+        "aliases": [
+            ""
+        ],
+        "elevation": 238,
+        "elevation_unit": "meter",
+        "latitude": 18.3442,
+        "latitude_unit": "degree",
+        "longitude": -66.7527,
+        "longitude_unit": "degree",
+        "name": "Arecibo Observatory",
+        "timezone": "America/Puerto_Rico",
+        "source": "Google maps"
     }
 }


### PR DESCRIPTION
Hi,

I used sites.json in a project I am working on, and found some inconsistencies and errors. They were:
 - a number of time zones were deprecated and some observatories had no time zone specified
 - Western longitudes were inconsistently specified, with a mixture of negative values, positive values greater than 180, and positive values less than 180, all used.
 - LBT latitude was wrong by 1 arcmin; others were slightly off
 - Tonantzintla elevation was incorrect.

Here is a pull request containing my fixes for these issues. I also defined some additional aliases, and added entries for two optical and eight radio observatories.