### PR TITLE
Make sites ascii again

### DIFF
--- a/coordinates/sites-un-ascii
+++ b/coordinates/sites-un-ascii
@@ -1,0 +1,2 @@
+# these are all mappings from the name in sites.json (which is ASCII-only) to the "true" unicode names
+TUBITAK->TÜBİTAK

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -661,7 +661,7 @@
     "tug": {
         "source": "TUG Website: http://www.tug.tubitak.gov.tr/gozlemevi.php",
         "elevation": 2500,
-        "name": "TÜBİTAK National Observatory",
+        "name": "TUBITAK National Observatory",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
         "latitude": 36.824166,


### PR DESCRIPTION
Discussed in more detail in #36 .  Should *not* be merged until consensus on the topic is reached in #36.

Note that this includes a file that's sort of "notes to us" with the ascii-to-non-ascii mapping.  The idea is that we can use that to restore the UTF-8 version in the future even if we merge this for now.