### PR TITLE
Add in JCMT and UKIRT to sites.json

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -687,5 +687,35 @@
     "elevation_unit": "meter",
     "name": "gbt",
     "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation"
+    },
+    "jcmt": {
+	"aliases": [
+	    "James Clerk Maxwell Telescope",
+	    "JCMT"
+	],
+	"name": "James Clerk Maxwell Telescope",
+	"elevation": 4124.75,
+	"elevation_unit": "meter",
+	"latitude": 19.8228,
+	"latitude_unit": "degree",
+	"longitude": 204.5230,
+	"longitude_unit": "degree",
+	"timezone": "US/Aleutian",
+	"source": "2007-04-11 GPS measurements by R. Tilanus (via Starlink/PAL)"
+    },
+    "ukirt": {
+	"aliases": [
+	    "UKIRT",
+	    "United Kingdom Infrared Telescope"
+	],
+	"name": "United Kingdom Infrared Telescope",
+	"elevation": 4198.50,
+	"elevation_unit": "meter",
+	"latitude": 19.8224306,
+	"latitude_unit": "degree",
+	"longitude": 204.529672,
+	"longitude_unit": "degree",
+	"timezone": "US/Aleutian",
+	"source": "IfA website via Starlink/PAL"
     }
 }


### PR DESCRIPTION
Adds in the lat/long/elevation/timezone for JCMT and UKIRT, based on positions in Starlink/PAL (https://github.com/Starlink/pal/blob/master/palObs.c)

The `test_sites.check_builtin_matches_remote' test succeeded on this commit.