### PR TITLE
Update sites.json for accurate location of Paranal

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -184,14 +184,14 @@
         ]
     },
     "paranal": {
-        "source": "ESO webpage",
-        "elevation": 2635,
+        "source": "Official reference in VLTI raw data products",
+        "elevation": 2669,
         "name": "Paranal Observatory (ESO)",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": -24.6252,
+        "latitude": -24.62743941,
         "elevation_unit": "meter",
-        "longitude": 289.597,
+        "longitude": -70.40498688,
         "timezone": "Chile/Continental",
         "aliases": [
             "Cerro Paranal",


### PR DESCRIPTION
This location is the origin of the local reference frame used to position everything on Paranal. The origin is the platform ground, and at 2/5 of the UT1 to UT2 distance. These coordinates can be found in the FITS headers of the datasets produced by the VLTI instruments.

HIERARCH ESO ISS GEOELEV = 2669.0 / VLTI ground site height above WGS84 [m].    
HIERARCH ESO ISS GEOLAT = -24.62743941 / VLTI site latitude (UV zero) [deg].    
HIERARCH ESO ISS GEOLON = -70.40498688 / VLTI site longitude (UV zero) [deg].