### PR TITLE
Adding the Teide Observatory on Tenerife

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -793,5 +793,20 @@
 	"longitude_unit": "degree",
 	"timezone": "US/Mountain",
 	"source": "NSO website: https://nsosp-dev.nso.edu/node/18"
+    },
+    "tenerife": {
+        "name": "Teide Observatory, Tenerife",
+        "source": "https://www.iac.es/en/observatorios-de-canarias/teide-observatory",
+        "elevation": 2390,
+        "elevation_unit": "meter",
+        "latitude_unit": "degree",
+        "latitude": 28.30207,
+        "longitude_unit": "degree",
+        "longitude": 343.48964,
+        "timezone": "Atlantic/Canary",
+        "aliases": [
+	"Observatorio del Teide",
+            "OT"
+        ]
     }
 }


### PR DESCRIPTION
Hi, I added an entry for the observatory I work at. I tried to run the tests listed in the coordinates readme but I got a numpy error in the testing. The error also occurred without my additions, so I'm not 100% sure whether it matters or I just don't have the correct environment to run the test...

Anyway, I'd be happy to have the request accepted and if I need to modify my environment and run the tests again in order to get it accepted, I'd be happy to do that as well.

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-8-f596e8f6fd18> in <module>
      2 
      3 
----> 4 test_sites.check_builtin_matches_remote('sites.json')

~/anaconda3/envs/sdc/lib/python3.7/site-packages/astropy/coordinates/tests/test_sites.py in check_builtin_matches_remote(download_url)
    153         in_dl[name] = name in dl_registry
    154         if in_dl[name]:
--> 155             matches[name] = quantity_allclose(builtin_registry[name], dl_registry[name])
    156         else:
    157             matches[name] = False

~/anaconda3/envs/sdc/lib/python3.7/site-packages/astropy/units/quantity.py in allclose(a, b, rtol, atol, **kwargs)
   1760     """
   1761     return np.allclose(*_unquantify_allclose_arguments(a, b, rtol, atol),
-> 1762                        **kwargs)
   1763 
   1764 

<__array_function__ internals> in allclose(*args, **kwargs)

~/anaconda3/envs/sdc/lib/python3.7/site-packages/numpy/core/numeric.py in allclose(a, b, rtol, atol, equal_nan)
   2157 
   2158     """
-> 2159     res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
   2160     return bool(res)
   2161 

<__array_function__ internals> in isclose(*args, **kwargs)

~/anaconda3/envs/sdc/lib/python3.7/site-packages/numpy/core/numeric.py in isclose(a, b, rtol, atol, equal_nan)
   2252     # This will cause casting of x later. Also, make sure to allow subclasses
   2253     # (e.g., for numpy.ma).
-> 2254     dt = multiarray.result_type(y, 1.)
   2255     y = array(y, dtype=dt, copy=False, subok=True)
   2256 

<__array_function__ internals> in result_type(*args, **kwargs)

TypeError: invalid type promotion
```