### PR TITLE
Add gravitational-wave observatories to sites list

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -793,5 +793,83 @@
 	"longitude_unit": "degree",
 	"timezone": "US/Mountain",
 	"source": "NSO website: https://nsosp-dev.nso.edu/node/18"
-    }
+    },
+    "geo_600": {
+        "name": "GEO600 Gravitational Wave Detector",
+        "aliases": [
+            "GEO",
+            "GEO_600",
+            "G1"
+        ],
+        "timezone": "Europe/Berlin",
+        "elevation": 114.42500305175781,
+        "elevation_unit": "meter",
+        "latitude": 52.24514666662807,
+        "latitude_unit": "degree",
+        "longitude": 9.807192777776013,
+        "longitude_unit": "degree",
+        "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
+    },
+    "llo_4k": {
+        "name": "LIGO Livingston Observatory",
+        "aliases": [
+            "LLO",
+            "LLO_4k",
+            "L1"
+        ],
+        "timezone": "US/Central",
+        "elevation": -6.573999881744385,
+        "elevation_unit": "meter",
+        "latitude": 30.562894333574896,
+        "latitude_unit": "degree",
+        "longitude": -90.77424038872107,
+        "longitude_unit": "degree",
+        "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
+    },
+    "lho_4k": {
+        "name": "LIGO Hanford Observatory",
+        "aliases": [
+            "LLO",
+            "LHO_4k",
+            "H1"
+        ],
+        "timezone": "US/Pacific",
+        "elevation": 142.5540008544922,
+        "elevation_unit": "meter",
+        "latitude": 46.45514666665509,
+        "latitude_unit": "degree",
+        "longitude": -119.40765713911102,
+        "longitude_unit": "degree",
+        "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
+    },
+    "kagra": {
+        "name": "Kamioka Gravitational Wave Detector",
+        "aliases": [
+            "KAGRA",
+            "K1"
+        ],
+        "timezone": "Asia/Tokyo",
+        "elevation": 414.1809997558594,
+        "elevation_unit": "meter",
+        "latitude": 36.41186033946475,
+        "latitude_unit": "degree",
+        "longitude": 137.3059560115472,
+        "longitude_unit": "degree",
+        "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
+    },
+    "virgo": {
+        "name": "Virgo Observatory",
+        "aliases": [
+            "Virgo",
+            "VIRGO",
+            "V1"
+        ],
+        "timezone": "Europe/Rome",
+        "elevation": 51.88399887084961,
+        "elevation_unit": "meter",
+        "latitude": 43.631414472074304,
+        "latitude_unit": "degree",
+        "longitude": 10.504496611198473,
+        "longitude_unit": "degree",
+        "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
 }


### PR DESCRIPTION
For convenience, these are exported from LALSuite using the following
Python code snippet:

```python
from astropy  import units as u
from astropy.coordinates.sites import SiteRegistry
from lal import CachedDetectors
import numpy as np
import json

sites = {
    'geo_600': {
        'name': 'GEO600 Gravitational Wave Detector',
        'aliases': ['GEO'],
        'timezone': 'Europe/Berlin'
    },
    'llo_4k': {
        'name': 'LIGO Livingston Observatory',
        'aliases': ['LLO'],
        'timezone': 'US/Central'
    },
    'lho_4k': {
        'name': 'LIGO Hanford Observatory',
        'aliases': ['LLO'],
        'timezone': 'US/Pacific'
    },
    'kagra': {
        'name': 'Kamioka Gravitational Wave Detector',
        'aliases': [],
        'timezone': 'Asia/Tokyo'
    },
    'virgo': {
        'name': 'Virgo Observatory',
        'aliases': ['Virgo'],
        'timezone': 'Europe/Rome'
    }
}

for key, value in sites.items():
    det, = (d for d in CachedDetectors if d.frDetector.name.lower() == key)
    value['aliases'] += [det.frDetector.name, det.frDetector.prefix]
    value['elevation'] = det.frDetector.vertexElevation
    value['elevation_unit'] = 'meter'
    value['latitude'] = np.rad2deg(det.frDetector.vertexLatitudeRadians)
    value['latitude_unit'] = 'degree'
    value['longitude'] = np.rad2deg(det.frDetector.vertexLongitudeRadians)
    value['latitude_unit'] = value['longitude_unit'] = 'degree'
    value['longitude_unit'] = 'degree'
    value['source'] = 'LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h'

registry = SiteRegistry.from_json(sites)
for key in sites:
    det, = (d for d in CachedDetectors if d.frDetector.name.lower() == key)
    result = u.Quantity(registry[key].geocentric).to_value(u.m)
    expected = det.location
    np.testing.assert_almost_equal(result, expected, decimal=3)

print(json.dumps(sites, indent=4))
```

This list excludes facilities that are R&D prototypes (such as
the Caltech 40m prototype), still under construction (such as LIGO
India), or planned for the future (such as Einstein Telescope).