### PR TITLE
Change DKIST coordinates and information source

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -753,14 +753,14 @@
 	    "ATST"
 	],
 	"name": "Daniel K. Inouye Solar Telescope",
-	"elevation": 3104,
+	"elevation": 3067,
 	"elevation_unit": "meter",
-	"latitude": 20.7047,
+	"latitude": 20.7067,
 	"latitude_unit": "degree",
-	"longitude": 203.8233,
+	"longitude": 203.7436,
 	"longitude_unit": "degree",
 	"timezone": "US/Aleutian",
-	"source": "DKIST website: http://dkist.nso.edu/faq"
+	"source": "DKIST website: https://www.nso.edu/telescopes/dki-solar-telescope/"
     },
     "bbso": {
 	"aliases": [


### PR DESCRIPTION
The DKIST coordinates were referencing the old NSO website. This commit updates that to the new NSO website and slightly changes the coordinates to match the information given there.