### PR TITLE
MNT: action-skip-ci has moved

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -20,7 +20,7 @@ jobs:
         BASEBRANCH_NAME: gh-pages
         SKIP_BASEBRANCH_CHECK_LABEL: skip-basebranch-check
     - name: Check skip CI
-      uses: pllim/action-skip-ci@main
+      uses: OpenAstronomy/action-skip-ci@main
       id: skip_ci_step
       with:
         NO_FAIL: true

--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -27,7 +27,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # This should only run if we did not skip CI
     - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@ce17749
+      uses: styfle/cancel-workflow-action@ce177499ccf9fd2aded3b0426c97e5434c2e8a73
       if: steps.skip_ci_step.outputs.run_next == 'true'
       with:
         access_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is an automated update made by the `batchpr` tool :robot: to because `action-skip-ci` has moved to a proper organization! You can report issues to @pllim.

xref OpenAstronomy/action-skip-ci#8