### PR TITLE
adding OVRO to sites.json

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -872,19 +872,17 @@
         "longitude": 10.504496611198473,
         "longitude_unit": "degree",
         "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
-    }
+    },
     "ovro": {
         "name": "Owens Valley Radio Observatory",
-        "aliases": [
-            "mma",
-        ],
+        "aliases": ["mma"],
         "timezone": "US/Pacific",
-        "elevation": 1188.05
+        "elevation": 1188.05,
         "elevation_unit": "meter",
         "latitude": 37.2334,
         "latitude_unit": "degree",
-        "longitude": -118.283
+        "longitude": -118.283,
         "longitude_unit": "degree",
         "source": "CASA software observatories list"
-    },
+    }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -873,4 +873,18 @@
         "longitude_unit": "degree",
         "source": "LALSuite: https://git.ligo.org/lscsoft/lalsuite/-/blob/lalsuite-v6.70/lal/lib/tools/LALDetectors.h"
     }
+    "ovro": {
+        "name": "Owens Valley Radio Observatory",
+        "aliases": [
+            "mma",
+        ],
+        "timezone": "US/Pacific",
+        "elevation": 1188.05
+        "elevation_unit": "meter",
+        "latitude": 37.2334,
+        "latitude_unit": "degree",
+        "longitude": -118.283
+        "longitude_unit": "degree",
+        "source": "CASA software observatories list"
+    },
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -877,12 +877,12 @@
         "name": "Owens Valley Radio Observatory",
         "aliases": ["mma"],
         "timezone": "US/Pacific",
-        "elevation": 1188.05,
+        "elevation": 1188.6,
         "elevation_unit": "meter",
-        "latitude": 37.2334,
+        "latitude": 37.233386982, 
         "latitude_unit": "degree",
-        "longitude": -118.283,
+        "longitude": -118.283405115,
         "longitude_unit": "degree",
-        "source": "CASA software observatories list"
+        "source": "OVRO staff measurement of center of T using GNSS"
     }
 }


### PR DESCRIPTION
This pull requests adds a new site to sites.json. The site is the Owens Valley Radio Observatory (OVRO). The coordinates are consistent with the value used in the field standard software, CASA. In CASA, the location is sometimes known as "MMA", which is noted in sites.json.