### PR TITLE
Update Sardinia Radio Telescope position

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -569,14 +569,14 @@
         ]
     },
     "srt": {
-        "source": "SRT website & google maps",
-        "elevation": 650.0,
+        "source": "SRT single dish tools & pulsar software such as TEMPO2 and PINT. Converted through EarthLocation(4865182.7660, 791922.6890, 4035137.1740, unit=u.m).to_geodetic()",
+        "elevation": 671.6665,
         "name": "Sardinia Radio Telescope",
         "longitude_unit": "degree",
         "latitude_unit": "degree",
-        "latitude": 39.493040,
+        "latitude": 39.49307239,
         "elevation_unit": "meter",
-        "longitude": 9.24516,
+        "longitude": 9.24515124,
         "timezone": "Europe/Rome",
         "aliases": [
              "SRT"

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -569,7 +569,7 @@
         ]
     },
     "srt": {
-        "source": "SRT single dish tools & pulsar software such as TEMPO2 and PINT. Converted through EarthLocation(4865182.7660, 791922.6890, 4035137.1740, unit=u.m).to_geodetic()",
+        "source": "SRT single dish tools & pulsar software such as TEMPO2 and PINT. Converted through EarthLocation(4865182.7660, 791922.6890, 4035137.1740, unit=u.m).to_geodetic() on 2022-11-21",
         "elevation": 671.6665,
         "name": "Sardinia Radio Telescope",
         "longitude_unit": "degree",


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This PR updates the position of the Sardinia Radio Telescope.
I used multiple sources which all agree between them: Pulsar software such as PINT and Tempo2, and the Sardinia Radio Telescope single dish tools. 
From the original position in meters, I used the conversion `EarthLocation(4865182.7660, 791922.6890, 4035137.1740, unit=u.m).to_geodetic()`.


<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

