### PR TITLE
Restore "Rubin Observatory" site name

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -565,6 +565,7 @@
              "LSST",
              "LSST 8.4m",
              "Rubin",
+             "Rubin Observatory",
              "rubin_sst",
              "rubin_simonyi",
              "Simonyi Survey Telescope",


### PR DESCRIPTION
In 828c713 I inadvertently removed "Rubin Observatory" when I renamed the entry to refer to the telescope not the observatory. This broke code for people and it needs to be added back in as an alias.

cc/ @cwwalter

Fixes #147
