### PR TITLE
Add location of SKA-Low and SKA-Mid telescopes

### DIFF
--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -1514,5 +1514,39 @@
              "Wendelstein Observatory",
              "wendelstein"
         ]
+    },
+    "ska-low": {
+        "name": "SKA-Low",
+        "elevation": 365.0,
+        "elevation_unit": "meter",
+        "latitude": -26.82472208,
+        "latitude_unit": "degree",
+        "longitude": 116.7644482,
+        "longitude_unit": "degree",
+        "source": "As specified in the ska-ost-array-config package, https://gitlab.com/ska-telescope/ost/ska-ost-array-config/-/blob/master/src/ska_ost_array_config/array_config.py \n Location documented in SKA-TEL-SKO-0000422 / 513-000001-CIV-1002",
+        "timezone": "Australia/Perth",
+	"aliases": [
+    	    "SKA-LOW",
+	    "SKA Low",
+	    "ska low",
+	    "skalow"
+	]
+    },
+    "ska-mid": {
+        "name": "SKA-Mid",
+        "elevation": 1095.967,
+        "elevation_unit": "meter",
+        "latitude": -30.71292499,
+        "latitude_unit": "degree",
+        "longitude": 21.44380263,
+        "longitude_unit": "degree",
+        "source": "As specified in the ska-ost-array-config package, https://gitlab.com/ska-telescope/ost/ska-ost-array-config/-/blob/master/src/ska_ost_array_config/array_config.py \n Location documented in SKA-TEL-INSA-0000537 Revision 11",
+        "timezone": "Africa/Johannesburg",
+	"aliases": [
+    	    "SKA-MID",
+	    "SKA Mid",
+	    "ska mid",
+	    "skamid"
+	]
     }
 }

--- a/coordinates/sites.json
+++ b/coordinates/sites.json
@@ -778,15 +778,13 @@
             "GBT",
             "Green Bank Observatory"
             ],
-        "elevation": 0,
+        "elevation": 807,
         "elevation_unit": "meter",
         "latitude": 38.433056,
         "latitude_unit": "degree",
         "longitude": -79.839722,
         "longitude_unit": "degree",
         "timezone": "US/Eastern",
-        "elevation": 807,
-        "elevation_unit": "meter",
         "name": "gbt",
         "source": "https://en.wikipedia.org/wiki/Green_Bank_Telescope + Google Elevation service for elevation"
     },


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our contributing guidelines,
https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md .
Please be sure to check out our code of conduct,
https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md . -->

<!-- If you are new or need to be re-acquainted with Astropy
contributing workflow, please see
http://docs.astropy.org/en/latest/development/workflow/development_workflow.html .
There is even a practical example at
https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example . -->

<!-- Astropy coding style guidelines can be found here:
https://docs.astropy.org/en/latest/development/codeguide.html#coding-style-conventions
Our testing infrastructure enforces to follow a subset of the PEP8 to be
followed. You can check locally whether your changes have followed these by
running the following command:

tox -e codestyle

-->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive
and allows maintainers to infer the applicable subpackage(s). -->

This pull request adds the location of the SKA-Low and SKA-Mid radio telescopes to `sites.json`. I am making this PR on behalf of the SKAO Science Operations team.

The location data are taken from the [SKAO `ska-ost-array-config` package](https://gitlab.com/ska-telescope/ost/ska-ost-array-config). These locations are based on internal SKAO documentation with identifiers: SKA-TEL-SKO-0000422, 513-000001-CIV-1002 and SKA-TEL-INSA-0000537 Revision 11. While the telescopes are still under construction, their array origin is fixed as specified here. 

I note that SKA telescope deployment follows a [staged delivery approach](https://www.skao.int/en/science-users/ska-tools/494/ska-staged-delivery-array-assemblies-and-subarrays), where the telescopes are made available for science/verification before construction of the full array is completed. Regardless, the array origin for each array does not change across array releases (i.e. the origin is a fixed location, _not_ the centroid of constituent stations within the array).

The pull request also fixes a duplicate `elevation` key in the `gbt` entry, which resulted in the JSON failing validation. 

<!-- If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number, GitHub will automatically link it.
If this pull request is unrelated to any issues, please remove
the following line. -->

